### PR TITLE
Update codecov config to be less strict on coverage changes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,6 @@ coverage:
   status:
     project:
       default:
-        threshold: 1%
+        threshold: 2.5%
         if_not_found: success # no commit found? still set a success
     patch: off


### PR DESCRIPTION
Updates the codecov config to allow for larger changes in code coverage before failing a PR. It seems codecov made some change to how they are computing coverage which is causing all current PRs to fail due to a perceived drop in coverage.