### PR TITLE
Remove feature request link

### DIFF
--- a/constants/Links.js
+++ b/constants/Links.js
@@ -45,15 +45,6 @@ export default [
 		}
 	},
 	{
-		key: 'links-feature',
-		name: 'links.feature',
-		url: 'https://features.jellyfin.org/',
-		icon: {
-			name: getIconName('create'),
-			type: 'ionicon'
-		}
-	},
-	{
 		key: 'links-issue',
 		name: 'links.issue',
 		url: 'https://github.com/jellyfin/jellyfin-expo/issues',

--- a/langs/en.json
+++ b/langs/en.json
@@ -69,7 +69,6 @@
     "documentation": "Documentation",
     "source": "Source Code",
     "translate": "Translate",
-    "feature": "Request a Feature",
     "issue": "Report an Issue"
   },
   "alerts": {


### PR DESCRIPTION
Removes the feature request link. It can be found in plenty of other places, so it doesn't seem necessary to include in the app, and could be contributing to some invalid requests.