### PR TITLE
Update icons

### DIFF
--- a/components/ServerInput.js
+++ b/components/ServerInput.js
@@ -98,7 +98,7 @@ const ServerInput = observer(React.forwardRef(
 					backgroundColor: theme.colors.searchBg
 				}}
 				leftIcon={{
-					name: getIconName('globe'),
+					name: getIconName('globe-outline'),
 					type: 'ionicon',
 					color: theme.colors.grey3
 				}}

--- a/components/ServerListItem.js
+++ b/components/ServerListItem.js
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
 		marginBottom: 2
 	},
 	leftElement: {
-		width: 12
+		width: 24
 	}
 });
 

--- a/constants/Links.js
+++ b/constants/Links.js
@@ -13,7 +13,7 @@ export default [
 		name: 'links.website',
 		url: 'https://jellyfin.org/',
 		icon: {
-			name: getIconName('globe'),
+			name: getIconName('globe-outline'),
 			type: 'ionicon'
 		}
 	},

--- a/navigation/TabNavigator.js
+++ b/navigation/TabNavigator.js
@@ -23,7 +23,7 @@ function TabIcon(routeName, color, size) {
 	if (routeName === Screens.HomeTab) {
 		iconName = getIconName('tv');
 	} else if (routeName === Screens.SettingsTab) {
-		iconName = getIconName('cog');
+		iconName = getIconName('cog-outline');
 	}
 
 	return (

--- a/navigation/TabNavigator.js
+++ b/navigation/TabNavigator.js
@@ -21,7 +21,7 @@ import HomeNavigator from './HomeNavigator';
 function TabIcon(routeName, color, size) {
 	let iconName = null;
 	if (routeName === Screens.HomeTab) {
-		iconName = getIconName('tv');
+		iconName = getIconName('tv-outline');
 	} else if (routeName === Screens.SettingsTab) {
 		iconName = getIconName('cog-outline');
 	}


### PR DESCRIPTION
Some of the icons looked a little off after updating Expo. This updates them to be more similar to the previous icons and fixes a spacing issue with the check for the currently selected server.

| Before | After |
|---|---|
| ![2400EFA3-61A2-4E6A-ACD5-F1B712B403CE](https://user-images.githubusercontent.com/3450688/136566207-28eea071-f305-4c9d-b9fc-afc51efda400.jpeg) | ![798ADF43-F4DA-4F6A-9526-AE3E214C5F85](https://user-images.githubusercontent.com/3450688/136566204-57b4c6dd-0ffe-4941-b48f-a9d42f41bd48.jpeg) |
| ![36AECC81-77FC-4646-80B6-C00C4824B30B](https://user-images.githubusercontent.com/3450688/136566210-ae697519-7ba6-4e72-b687-b612c38604e6.jpeg) | ![E9FA20D6-7751-4971-8B4F-9E7035F5F557](https://user-images.githubusercontent.com/3450688/136566208-acd27211-bdce-43c5-847b-28f5af6eeb92.jpeg) |

(The weird arrows are fixed by upgrading react-native-elements in #305.)

Depends on #301 