### PR TITLE
Update dependencies

### DIFF
--- a/components/__tests__/BrowserListItem.test.js
+++ b/components/__tests__/BrowserListItem.test.js
@@ -9,9 +9,9 @@ import React from 'react';
 import { openBrowser } from '../../utils/WebBrowser';
 import BrowserListItem from '../BrowserListItem';
 
-jest.mock('react-native-elements/src/icons/Icon', () => {
+jest.mock('react-native-elements/dist/icons/Icon', () => {
 	const mockComponent = require('react-native/jest/mockComponent');
-	return mockComponent('react-native-elements/src/icons/Icon');
+	return mockComponent('react-native-elements/dist/icons/Icon');
 });
 
 jest.mock('../../utils/WebBrowser');

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,7 +5,7 @@
  */
 
 import { enableFetchMocks } from 'jest-fetch-mock';
-import AbortController from 'node-abort-controller';
+import { AbortController } from 'node-abort-controller';
 
 global.AbortController = AbortController;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11936,9 +11936,9 @@
       }
     },
     "i18next": {
-      "version": "19.9.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.9.2.tgz",
-      "integrity": "sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==",
+      "version": "21.2.4",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.2.4.tgz",
+      "integrity": "sha512-+81XmiwJOLWJFjRZJK5ASFahAo5TXZGz5IrBT4CfLJ3CyXho61A1cj1Kmh8za8TYtGFou0cEkUSjEaqfya7Wfg==",
       "requires": {
         "@babel/runtime": "^7.12.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8930,9 +8930,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
-      "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
+      "integrity": "sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==",
       "dev": true
     },
     "eslint-plugin-react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4323,37 +4323,83 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.24",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
-      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
+      "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
       "dev": true,
       "requires": {
-        "jest-diff": "^26.0.0",
-        "pretty-format": "^26.0.0"
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "27.2.4",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
+          "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "16.0.4",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
         "diff-sequences": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-          "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+          "version": "27.0.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+          "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
           "dev": true
         },
         "jest-diff": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
-          "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+          "version": "27.2.4",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.4.tgz",
+          "integrity": "sha512-bLAVlDSCR3gqUPGv+4nzVpEXGsHh98HjUL7Vb2hVyyuBDoQmja8eJb0imUABsuxBeUVmf47taJSAd9nDrwWKEg==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^26.6.2",
-            "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.6.2"
+            "diff-sequences": "^27.0.6",
+            "jest-get-type": "^27.0.6",
+            "pretty-format": "^27.2.4"
           }
         },
         "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+          "version": "27.0.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+          "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.2.4",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.4.tgz",
+          "integrity": "sha512-NUjw22WJHldzxyps2YjLZkUj6q1HvjqFezkB9Y2cklN8NtVZN/kZEXGZdFw4uny3oENzV5EEMESrkI0YDUH8vg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.2.4",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17528,9 +17528,9 @@
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
     },
     "node-abort-controller": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.2.1.tgz",
-      "integrity": "sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==",
       "dev": true
     },
     "node-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20597,19 +20597,18 @@
       }
     },
     "react-native-elements": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/react-native-elements/-/react-native-elements-2.3.2.tgz",
-      "integrity": "sha512-HygYYmq8JYjk/YYiUwr/64qT64H2xlPBz0JnkGTQwvnnyXZrfkHFopw8rLWCupv3iLLPDzVohvPs0Z5HLdonSQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/react-native-elements/-/react-native-elements-3.4.2.tgz",
+      "integrity": "sha512-m0eAWOn7JuR1wNTNY0WHuaqst4LI/gFE4N5Bbyfsc4DiryWsMST7aAg5w/Gos4IexWIzhLKCIkPxthND1m/8Xg==",
       "requires": {
-        "@types/react-native-vector-icons": "^6.4.5",
-        "color": "^3.1.0",
+        "@types/react-native-vector-icons": "^6.4.6",
+        "color": "^3.1.2",
         "deepmerge": "^4.2.2",
-        "hoist-non-react-statics": "^3.1.0",
+        "hoist-non-react-statics": "^3.3.2",
         "lodash.isequal": "^4.5.0",
-        "opencollective-postinstall": "^2.0.0",
-        "prop-types": "^15.7.2",
-        "react-native-ratings": "^7.2.0",
-        "react-native-status-bar-height": "^2.5.0"
+        "opencollective-postinstall": "^2.0.3",
+        "react-native-ratings": "8.0.4",
+        "react-native-size-matters": "^0.3.1"
       },
       "dependencies": {
         "deepmerge": {
@@ -20653,12 +20652,11 @@
       "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg=="
     },
     "react-native-ratings": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-7.6.1.tgz",
-      "integrity": "sha512-V3y19iIifwemMr87KfovFIIzy/Rotqcds9k+ECaayQvrlucm/mXFC69R8xl/NivEdnxX7K87iurigByhpE37EQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-8.0.4.tgz",
+      "integrity": "sha512-Xczu5lskIIRD6BEdz9A0jDRpEck/SFxRqiglkXi0u67yAtI1/pcJC76P4MukCbT8K4BPVl+42w83YqXBoBRl7A==",
       "requires": {
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2"
+        "lodash": "^4.17.15"
       }
     },
     "react-native-reanimated": {
@@ -20701,10 +20699,10 @@
         "warn-once": "^0.1.0"
       }
     },
-    "react-native-status-bar-height": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-native-status-bar-height/-/react-native-status-bar-height-2.6.0.tgz",
-      "integrity": "sha512-z3SGLF0mHT+OlJDq7B7h/jXPjWcdBT3V14Le5L2PjntjjWM3+EJzq2BcXDwV+v67KFNJic5pgA26cCmseYek6w=="
+    "react-native-size-matters": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.3.1.tgz",
+      "integrity": "sha512-mKOfBLIBFBcs9br1rlZDvxD5+mAl8Gfr5CounwJtxI6Z82rGrMO+Kgl9EIg3RMVf3G855a85YVqHJL2f5EDRlw=="
     },
     "react-native-webview": {
       "version": "11.6.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jest": "^24.1.5",
-    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-native": "^3.10.0",
     "expo-cli": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-lifecycles-compat": "^3.0.4",
     "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
     "react-native-appearance": "~0.3.3",
-    "react-native-elements": "^2.3.0",
+    "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "expo-splash-screen": "~0.11.2",
     "expo-status-bar": "~1.0.4",
     "expo-web-browser": "~9.2.0",
-    "i18next": "^19.6.0",
+    "i18next": "^21.2.4",
     "mobx": "^5.15.4",
     "mobx-react": "^6.2.2",
     "mobx-sync": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "expo-cli": "^4.12.1",
     "jest-expo": "^42.0.0",
     "jest-fetch-mock": "^3.0.3",
-    "node-abort-controller": "^1.1.0",
+    "node-abort-controller": "^3.0.1",
     "typescript": "~4.0.0"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@babel/eslint-parser": "^7.12.1",
     "@testing-library/jest-native": "^4.0.0",
     "@testing-library/react-native": "^7.2.0",
-    "@types/jest": "^26.0.20",
+    "@types/jest": "^27.0.2",
     "@typescript-eslint/parser": "^4.9.1",
     "babel-preset-expo": "8.3.0",
     "eslint": "^7.4.0",


### PR DESCRIPTION
Updates the following dependencies that are not managed by Expo:

* @types/jest
* eslint-plugin-promise
* i18next
* node-abort-controller
* react-native-elements

Begins work on #302 (react-navigation will likely require more significant changes so it will be a separate PR)

Blocked by #301 