### PR TITLE
Update AsyncStorage

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 import { Ionicons } from '@expo/vector-icons';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer } from '@react-navigation/native';
 import AppLoading from 'expo-app-loading';
 import { Asset } from 'expo-asset';
@@ -14,7 +15,6 @@ import { observer } from 'mobx-react';
 import { AsyncTrunk } from 'mobx-sync';
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
-import { AsyncStorage } from 'react-native';
 import { AppearanceProvider, useColorScheme } from 'react-native-appearance';
 import { ThemeContext, ThemeProvider } from 'react-native-elements';
 import { SafeAreaProvider } from 'react-native-safe-area-context';

--- a/package-lock.json
+++ b/package-lock.json
@@ -3604,6 +3604,14 @@
         "read-package-json-fast": "^2.0.1"
       }
     },
+    "@react-native-async-storage/async-storage": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.9.tgz",
+      "integrity": "sha512-LrVPfhKqodRiDWCgZp7J2X55JQqOhdQUxbl17RrktIGCZ0ud2XHdNoTIvyI1VccqHoF/CZK6v+G0IoX5NYZ1JA==",
+      "requires": {
+        "merge-options": "^3.0.4"
+      }
+    },
     "@react-native-community/cli-debugger-ui": {
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz",
@@ -16244,6 +16252,21 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
+    },
+    "merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "requires": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        }
+      }
     },
     "merge-stream": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.4.0",
-    "react-native-webview": "11.6.2"
+    "react-native-webview": "11.6.2",
+    "@react-native-async-storage/async-storage": "~1.15.0"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -3,13 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
 import compareVersions from 'compare-versions';
 import { action } from 'mobx';
 import { observer } from 'mobx-react';
 import React, { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Alert, AsyncStorage, Platform, SectionList, StyleSheet, View } from 'react-native';
+import { Alert, Platform, SectionList, StyleSheet, View } from 'react-native';
 import { Text, ThemeContext } from 'react-native-elements';
 import { SafeAreaView } from 'react-native-safe-area-context';
 


### PR DESCRIPTION
AsyncStorage was moved to a separate library. The version included in React Native is deprecated.

Depends on #306 