### PR TITLE
Remove deprecated device id

### DIFF
--- a/components/NativeShellWebView.js
+++ b/components/NativeShellWebView.js
@@ -27,12 +27,11 @@ const NativeShellWebView = observer(React.forwardRef(
 		const server = rootStore.serverStore.servers[rootStore.settingStore.activeServer];
 		const isPluginSupported = !!server.info?.Version && compareVersions.compare(server.info.Version, '10.7', '>=');
 
-		// FIXME: Constants.deviceId has been deprecated. We need to generate a unique id instead.
 		const injectedJavaScript = `
 window.ExpoAppInfo = {
 	appName: '${getAppName()}',
 	appVersion: '${Constants.nativeAppVersion}',
-	deviceId: '${Constants.deviceId}',
+	deviceId: '${rootStore.deviceId}',
 	deviceName: '${getSafeDeviceName().replace(/'/g, '\\\'')}'
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3826,6 +3826,13 @@
           "requires": {
             "simple-plist": "^1.0.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
           }
         }
       }
@@ -9559,6 +9566,11 @@
             "expo-modules-core": "~0.2.0",
             "uuid": "^3.3.2"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -10041,6 +10053,11 @@
             "xmlbuilder": "^14.0.0",
             "xmldom": "~0.5.0"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -10065,6 +10082,13 @@
         "@expo/config-plugins": "^3.0.0",
         "expo-modules-core": "~0.2.0",
         "uuid": "^3.4.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "expo-font": {
@@ -10503,6 +10527,11 @@
         "parse-node-version": "^1.0.0",
         "time-stamp": "^1.0.0"
       }
+    },
+    "fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -11344,6 +11373,14 @@
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "growly": {
@@ -20722,6 +20759,14 @@
         }
       }
     },
+    "react-native-get-random-values": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.7.0.tgz",
+      "integrity": "sha512-zDhmpWUekGRFb9I+MQkxllHcqXN9HBSsgPwBQfrZ1KZYpzDspWLZ6/yLMMZrtq4pVqNR7C7N96L3SuLpXv1nhQ==",
+      "requires": {
+        "fast-base64-decode": "^1.0.0"
+      }
+    },
     "react-native-ratings": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-8.0.4.tgz",
@@ -21194,6 +21239,12 @@
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -21991,6 +22042,14 @@
         "faye-websocket": "^0.10.0",
         "uuid": "^3.4.0",
         "websocket-driver": "0.6.5"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "sockjs-client": {
@@ -23772,9 +23831,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -25098,6 +25157,12 @@
           "version": "3.2.4",
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
           "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "Android >= 5"
   ],
   "dependencies": {
+    "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/bottom-tabs": "^6.0.7",
     "@react-navigation/native": "^6.0.4",
@@ -63,11 +64,12 @@
     "react-native-appearance": "~0.3.3",
     "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "~1.10.2",
+    "react-native-get-random-values": "^1.7.0",
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.4.0",
     "react-native-webview": "11.6.2",
-    "@react-native-async-storage/async-storage": "~1.15.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/stores/RootStore.js
+++ b/stores/RootStore.js
@@ -3,14 +3,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { decorate, observable } from 'mobx';
+
+// polyfill crypto.getRandomValues
+import 'react-native-get-random-values';
+
+import { action, decorate, observable } from 'mobx';
 import { ignore } from 'mobx-sync';
+import { v4 as uuidv4 } from 'uuid';
 
 import MediaStore from './MediaStore';
 import ServerStore from './ServerStore';
 import SettingStore from './SettingStore';
 
 export default class RootStore {
+	/**
+	 * Generate a random unique device id
+	 */
+	deviceId = uuidv4()
+
 	/**
 	 * Has the store been loaded from storage
 	 */
@@ -36,6 +46,8 @@ export default class RootStore {
 	settingStore = new SettingStore()
 
 	reset() {
+		this.deviceId = uuidv4();
+
 		this.isFullscreen = false;
 		this.isReloadRequired = false;
 		this.didPlayerCloseManually = true;
@@ -49,8 +61,10 @@ export default class RootStore {
 }
 
 decorate(RootStore, {
+	deviceId: observable,
 	storeLoaded: [ ignore, observable ],
 	isFullscreen: [ ignore, observable ],
 	isReloadRequired: [ ignore, observable ],
-	didPlayerCloseManually: [ ignore, observable ]
+	didPlayerCloseManually: [ ignore, observable ],
+	reset: action
 });


### PR DESCRIPTION
Removes the deprecated usage of Expo's device id constant and replaces it with a randomly generated id in the root store.

Depends on #311 