### PR TITLE
Add SwiftUI as optional library for iOS 12

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "platforms": [
       "ios"
     ],
-    "version": "1.6.0",
+    "version": "1.6.1",
     "orientation": "default",
     "primaryColor": "#00a4dc",
     "backgroundColor": "#101010",
@@ -26,7 +26,7 @@
       "**/*"
     ],
     "ios": {
-      "buildNumber": "5.6.0.2",
+      "buildNumber": "1.6.1.0",
       "supportsTablet": true,
       "requireFullScreen": false,
       "bundleIdentifier": "org.jellyfin.expo",

--- a/ios/Jellyfin.xcodeproj/project.pbxproj
+++ b/ios/Jellyfin.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2C12A4B19C954DC0A8B0A1A1 /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2CFF3463DF4D8CB087A118 /* noop-file.swift */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		96905EF65AED1B983A6B3ABC /* libPods-Jellyfin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-Jellyfin.a */; };
+		A9FAF1392D78B03C0071152B /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9FAF1382D78B03C0071152B /* SwiftUI.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 /* End PBXBuildFile section */
@@ -29,6 +30,7 @@
 		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-Jellyfin.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Jellyfin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C2E3173556A471DD304B334 /* Pods-Jellyfin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Jellyfin.debug.xcconfig"; path = "Target Support Files/Pods-Jellyfin/Pods-Jellyfin.debug.xcconfig"; sourceTree = "<group>"; };
 		7A4D352CD337FB3A3BF06240 /* Pods-Jellyfin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Jellyfin.release.xcconfig"; path = "Target Support Files/Pods-Jellyfin/Pods-Jellyfin.release.xcconfig"; sourceTree = "<group>"; };
+		A9FAF1382D78B03C0071152B /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Jellyfin/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -40,6 +42,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9FAF1392D78B03C0071152B /* SwiftUI.framework in Frameworks */,
 				96905EF65AED1B983A6B3ABC /* libPods-Jellyfin.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -66,6 +69,7 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A9FAF1382D78B03C0071152B /* SwiftUI.framework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-Jellyfin.a */,
 			);

--- a/ios/Jellyfin/Info.plist
+++ b/ios/Jellyfin/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.6.0</string>
+    <string>1.6.1</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -30,7 +30,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>5.6.0.2</string>
+    <string>1.6.1.0</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-expo",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-expo",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",


### PR DESCRIPTION
* Fixes iOS 12 crashing on launch due to missing SwiftUI reference
* Bumps version numbers for 1.6.1

Fixes #612 