### PR TITLE
Update quick start link

### DIFF
--- a/constants/Links.js
+++ b/constants/Links.js
@@ -5,7 +5,7 @@
  */
 import { getIconName } from '../utils/Icons';
 
-export const QuickStartUrl = 'https://jellyfin.org/docs/general/quick-start.html';
+export const QuickStartUrl = 'https://jellyfin.org/docs/general/quick-start';
 
 export default [
 	{

--- a/constants/__tests__/Links.test.js
+++ b/constants/__tests__/Links.test.js
@@ -9,6 +9,6 @@ import { QuickStartUrl } from '../Links';
 // I don't understand why jest thinks this needs test coverage, but it does =/
 describe('Links', () => {
 	it('should return the right url', () => {
-		expect(QuickStartUrl).toBe('https://jellyfin.org/docs/general/quick-start.html');
+		expect(QuickStartUrl).toBe('https://jellyfin.org/docs/general/quick-start');
 	});
 });


### PR DESCRIPTION
The `.html` extension is a leftover from the old docs site that hasn't existed in several years.

Closes #658 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Quick Start link to point to the current documentation URL, ensuring users are directed to the correct page.

* **Tests**
  * Adjusted test expectations to align with the updated Quick Start URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->