### PR TITLE
Disable download selection when pending

### DIFF
--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -91,6 +91,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 					checked={isSelected}
 					disabled={!item.isComplete}
 					accessibilityRole='checkbox'
+					accessibilityState={{ checked: isSelected, disabled: !item.isComplete }}
 				/>
 			}
 			<ListItem.Content>

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -85,12 +85,13 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 			accessibilityState={{ disabled: !item.isComplete }}
 		>
 			{isEditMode &&
-			<ListItem.CheckBox
-				testID='select-checkbox'
-				onPress={onSelect}
-				checked={isSelected}
-				accessibilityRole='checkbox'
-			/>
+				<ListItem.CheckBox
+					testID='select-checkbox'
+					onPress={onSelect}
+					checked={isSelected}
+					disabled={!item.isComplete}
+					accessibilityRole='checkbox'
+				/>
 			}
 			<ListItem.Content>
 				<ListItem.Title


### PR DESCRIPTION
We should handle cancelling in progress downloads in the future, but for now it triggers a weird error state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the edit-mode checkbox for incomplete items, aligning with the rule that only completed items are interactive.
  * Prevents accidental activation via either the row or the checkbox until an item is complete.
  * Preserves labels and interactions for completed items.
  * Checkbox now exposes an explicit accessibility state for clearer screen-reader feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->