### PR TITLE
Cleanup profile names and transcode context

### DIFF
--- a/utils/Device.ts
+++ b/utils/Device.ts
@@ -12,10 +12,10 @@ import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import { Platform } from 'react-native';
 
-import iOSProfile from './profiles/ios';
 import iOS10Profile from './profiles/ios-10';
-import iOS12Profile from './profiles/ios-12';
-import iOSFmp4Profile from './profiles/ios-fmp4';
+import iOS11Profile from './profiles/ios-11';
+import iOS13Profile from './profiles/ios-13';
+import iOS13Fmp4Profile from './profiles/ios-13-fmp4';
 
 /** Gets the app name used for API requests. */
 export function getAppName() {
@@ -50,11 +50,11 @@ export function getDeviceProfile({ enableFmp4 = false } = {}): DeviceProfile {
 		if (compareVersions.compare(Platform.Version, '11', '<')) {
 			return iOS10Profile;
 		} else if (compareVersions.compare(Platform.Version, '13', '<')) {
-			return iOS12Profile;
+			return iOS11Profile;
 		} else if (enableFmp4) {
-			return iOSFmp4Profile;
+			return iOS13Fmp4Profile;
 		} else {
-			return iOSProfile;
+			return iOS13Profile;
 		}
 	}
 	// NOTE: Other platforms are not supported

--- a/utils/__tests__/Device.test.js
+++ b/utils/__tests__/Device.test.js
@@ -8,10 +8,10 @@ import * as Device from 'expo-device';
 import { Platform } from 'react-native';
 
 import { getAppName, getAppDisplayName, getDeviceProfile, getSafeDeviceName, isCompact, isSystemThemeSupported } from '../Device';
-import iOSProfile from '../profiles/ios';
 import iOS10Profile from '../profiles/ios-10';
-import iOS12Profile from '../profiles/ios-12';
-import iOSFmp4Profile from '../profiles/ios-fmp4';
+import iOS11Profile from '../profiles/ios-11';
+import iOSProfile from '../profiles/ios-13';
+import iOSFmp4Profile from '../profiles/ios-13-fmp4';
 
 jest.mock('react-native/Libraries/Utilities/Platform');
 
@@ -61,12 +61,12 @@ describe('Device', () => {
 
 		it('should return the correct profile for iOS 11 devices', () => {
 			Platform.Version = '11';
-			expect(getDeviceProfile()).toBe(iOS12Profile);
+			expect(getDeviceProfile()).toBe(iOS11Profile);
 		});
 
 		it('should return the correct profile for iOS 12 devices', () => {
 			Platform.Version = '12';
-			expect(getDeviceProfile()).toBe(iOS12Profile);
+			expect(getDeviceProfile()).toBe(iOS11Profile);
 		});
 
 		it('should return the correct profile for iOS 13 devices', () => {

--- a/utils/profiles/base.ts
+++ b/utils/profiles/base.ts
@@ -13,7 +13,7 @@ import { ProfileConditionValue } from '@jellyfin/sdk/lib/generated-client/models
 import { SubtitleDeliveryMethod } from '@jellyfin/sdk/lib/generated-client/models/subtitle-delivery-method';
 
 const BaseProfile = {
-	Name: 'Expo Base Video Profile',
+	Name: 'Base Native Profile',
 	MaxStaticBitrate: 100000000, // 100 Mbps
 	MaxStreamingBitrate: 120000000, // 120 Mbps
 	MusicStreamingTranscodingBitrate: 384000, // 384 kbps

--- a/utils/profiles/ios-10.ts
+++ b/utils/profiles/ios-10.ts
@@ -21,7 +21,7 @@ import BaseProfile from './base';
  */
 const Ios10Profile = {
 	...BaseProfile,
-	Name: 'Expo iOS 10 Video Profile',
+	Name: 'iOS 10+ Native Profile',
 	CodecProfiles: [
 		// iOS<13 only supports max h264 level 4.2 in ts containers
 		{
@@ -177,10 +177,19 @@ const Ios10Profile = {
 			Type: DlnaProfileType.Video,
 			VideoCodec: 'h264'
 		},
+		// NOTE: Video transcoding profiles with a static context value seem ignored?
 		{
 			AudioCodec: 'aac,mp3,dca,dts,alac',
 			Container: 'mp4',
 			Context: EncodingContext.Static,
+			Protocol: MediaStreamProtocol.Http,
+			Type: DlnaProfileType.Video,
+			VideoCodec: 'h264'
+		},
+		{
+			AudioCodec: 'aac,mp3,dca,dts,alac',
+			Container: 'mp4',
+			Context: EncodingContext.Streaming,
 			Protocol: MediaStreamProtocol.Http,
 			Type: DlnaProfileType.Video,
 			VideoCodec: 'h264'

--- a/utils/profiles/ios-11.ts
+++ b/utils/profiles/ios-11.ts
@@ -11,14 +11,14 @@ import type { DeviceProfile } from '@jellyfin/sdk/lib/generated-client/models/de
 import { ProfileConditionType } from '@jellyfin/sdk/lib/generated-client/models/profile-condition-type';
 import { ProfileConditionValue } from '@jellyfin/sdk/lib/generated-client/models/profile-condition-value';
 
-import iOSProfile from './ios';
+import iOSProfile from './ios-13';
 
 /**
  * Device profile for Expo Video player on iOS 11-12
  */
-const Ios12Profile = {
+const Ios11Profile = {
 	...iOSProfile,
-	Name: 'Expo iOS 12 Video Profile',
+	Name: 'iOS 11+ Native Profile',
 	CodecProfiles: [
 		// iOS<13 only supports max h264 level 4.2 in ts containers
 		{
@@ -56,4 +56,4 @@ const Ios12Profile = {
 	]
 } satisfies DeviceProfile;
 
-export default Ios12Profile;
+export default Ios11Profile;

--- a/utils/profiles/ios-13-fmp4.ts
+++ b/utils/profiles/ios-13-fmp4.ts
@@ -11,14 +11,14 @@ import { DlnaProfileType } from '@jellyfin/sdk/lib/generated-client/models/dlna-
 import { EncodingContext } from '@jellyfin/sdk/lib/generated-client/models/encoding-context';
 import { MediaStreamProtocol } from '@jellyfin/sdk/lib/generated-client/models/media-stream-protocol';
 
-import iOSProfile from './ios';
+import iOSProfile from './ios-13';
 
 /**
  * Device profile for Expo Video player on iOS 13+ with fMP4 support
  */
 const IosFmp4Profile = {
 	...iOSProfile,
-	Name: 'Expo iOS fMP4 Video Profile',
+	Name: iOSProfile.Name + ' + fMP4',
 	TranscodingProfiles: [
 		// Add all audio profiles from default profile
 		...iOSProfile.TranscodingProfiles.filter(profile => profile.Type === DlnaProfileType.Audio),

--- a/utils/profiles/ios-13.ts
+++ b/utils/profiles/ios-13.ts
@@ -18,7 +18,7 @@ import BaseProfile from './base';
  */
 const IosProfile = {
 	...BaseProfile,
-	Name: 'Expo iOS Video Profile',
+	Name: 'iOS 13+ Native Profile',
 	DirectPlayProfiles: [
 		{
 			AudioCodec: 'aac,mp3,ac3,eac3,flac,alac',
@@ -143,10 +143,19 @@ const IosProfile = {
 			Type: DlnaProfileType.Video,
 			VideoCodec: 'h264'
 		},
+		// NOTE: Video transcoding profiles with a static context value seem ignored?
 		{
 			AudioCodec: 'aac,mp3,ac3,eac3,flac,alac',
 			Container: 'mp4',
 			Context: EncodingContext.Static,
+			Protocol: MediaStreamProtocol.Http,
+			Type: DlnaProfileType.Video,
+			VideoCodec: 'h264'
+		},
+		{
+			AudioCodec: 'aac,mp3,ac3,eac3,flac,alac',
+			Container: 'mp4',
+			Context: EncodingContext.Streaming,
 			Protocol: MediaStreamProtocol.Http,
 			Type: DlnaProfileType.Video,
 			VideoCodec: 'h264'


### PR DESCRIPTION
* Minor cleanup to standardize profile names based on the minimum iOS version
* Add "Streaming" transcode profiles since "Static" seems to be ignored by the server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded iOS playback support with new native profiles for iOS 11+ and iOS 13+.
  * Added an iOS 13 fMP4 profile variant for improved compatibility when fMP4 is enabled.
  * Enhanced direct play options: H.264 MP4 over HTTP with broader audio codec support (AAC/MP3/AC3/E-AC3/FLAC/ALAC) for static and streaming contexts.

* **Improvements**
  * Updated device detection to select more accurate profiles: iOS 11/12 now use the iOS 11 profile; iOS 13+ uses the iOS 13 profile.
  * Renamed profiles to clearer “Native Profile” titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->