### PR TITLE
Add file management permissions

### DIFF
--- a/app.json
+++ b/app.json
@@ -38,7 +38,9 @@
         "UIBackgroundModes": [
           "audio",
           "fetch"
-        ]
+        ],
+        "LSSupportsOpeningDocumentsInPlace": true,
+        "UIFileSharingEnabled": true
       }
     },
     "description": "Jellyfin"

--- a/ios/Jellyfin/Info.plist
+++ b/ios/Jellyfin/Info.plist
@@ -33,6 +33,8 @@
     <string>1.7.0.4</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
     <key>NSAppTransportSecurity</key>
     <dict>
       <key>NSAllowsArbitraryLoads</key>
@@ -57,6 +59,8 @@
       <string>audio</string>
       <string>fetch</string>
     </array>
+    <key>UIFileSharingEnabled</key>
+    <true/>
     <key>UILaunchStoryboardName</key>
     <string>SplashScreen</string>
     <key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
Adds file management permissions to allow opening downloads in the Files app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS: App documents are now visible in the Files app for easier access and management.
  * iOS: Supports File Sharing via Finder/iTunes, enabling import/export of files to and from the app.
  * iOS: Allows opening and editing documents in place from external sources without creating duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->