### PR TITLE
Add files app integration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,7 @@
     "expo-file-system",
     "expo-font",
     "expo-keep-awake",
+    "expo-linking",
     "expo-localization",
     "expo-screen-orientation",
     "expo-splash-screen",

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -19,6 +19,7 @@ interface DownloadListItemProps {
 	item: DownloadModel;
 	index: number;
 	onSelect: () => void;
+	onOpen: () => void;
 	onPlay: () => void;
 	onDelete: () => void;
 	isEditMode?: boolean;
@@ -29,6 +30,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 	item,
 	index,
 	onSelect,
+	onOpen,
 	onPlay,
 	onDelete,
 	isEditMode = false,
@@ -44,8 +46,10 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 	const onItemPress = useCallback(() => {
 		// Call select callback if in edit mode
 		if (isEditMode) onSelect();
-		// Otherwise call play callback
+		// Call play if item is playable in app
 		else if (canPlayInApp) onPlay();
+		// Otherwise open the item
+		else onOpen();
 	}, [ canPlayInApp, isEditMode, onPlay, onSelect ]);
 
 	return (
@@ -53,7 +57,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 			testID='list-item'
 			topDivider={index === 0}
 			bottomDivider
-			onPress={item.isComplete && (isEditMode || canPlayInApp) ? onItemPress : undefined}
+			onPress={item.isComplete ? onItemPress : undefined}
 		>
 			{isEditMode &&
 				<ListItem.CheckBox
@@ -87,6 +91,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 				canPlayInApp={canPlayInApp}
 				isEditMode={isEditMode}
 				onDelete={onDelete}
+				onOpen={onOpen}
 				onPlay={onPlay}
 			/>
 		</ListItem>

--- a/components/DownloadListItem.tsx
+++ b/components/DownloadListItem.tsx
@@ -50,7 +50,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 		else if (canPlayInApp) onPlay();
 		// Otherwise open the item
 		else onOpen();
-	}, [ canPlayInApp, isEditMode, onPlay, onSelect ]);
+	}, [ canPlayInApp, isEditMode, onOpen, onPlay, onSelect ]);
 
 	return (
 		<ListItem

--- a/components/DownloadStatusIndicator.tsx
+++ b/components/DownloadStatusIndicator.tsx
@@ -62,7 +62,7 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 			...actions,
 			{
 				id: DownloadAction.OpenInFiles,
-				title: 'Open in Files',
+				title: t('common.openInFiles'),
 				image: 'folder'
 			},
 			{

--- a/components/DownloadStatusIndicator.tsx
+++ b/components/DownloadStatusIndicator.tsx
@@ -25,11 +25,13 @@ interface DownloadStatusIndicatorProps {
 	canPlayInApp: boolean;
 	isEditMode?: boolean;
 	onDelete: () => void;
+	onOpen: () => void;
 	onPlay: () => void;
 }
 
 const DownloadAction = {
 	Delete: 'delete',
+	OpenInFiles: 'open_in_files',
 	PlayInApp: 'play_in_app'
 } as const;
 
@@ -38,6 +40,7 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 	canPlayInApp,
 	isEditMode = false,
 	onDelete,
+	onOpen,
 	onPlay
 }) => {
 	const { settingStore } = useStores();
@@ -58,6 +61,11 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 		return [
 			...actions,
 			{
+				id: DownloadAction.OpenInFiles,
+				title: 'Open in Files',
+				image: 'folder'
+			},
+			{
 				id: DownloadAction.Delete,
 				title: t('common.delete'),
 				attributes: {
@@ -70,6 +78,8 @@ const DownloadStatusIndicator: FC<DownloadStatusIndicatorProps> = ({
 
 	const onMenuPress = useCallback(({ nativeEvent }: MenuPressEvent) => {
 		switch (nativeEvent.event) {
+			case DownloadAction.OpenInFiles:
+				return onOpen();
 			case DownloadAction.PlayInApp:
 				return onPlay();
 			case DownloadAction.Delete:

--- a/components/__tests__/DownloadListItem.test.js
+++ b/components/__tests__/DownloadListItem.test.js
@@ -43,8 +43,9 @@ describe('DownloadListItem', () => {
 				item={model}
 				index={0}
 				onSelect={onSelect}
+				onOpen={jest.fn()}
 				onPlay={onPlay}
-				onDelete={() => { /* no-op */ }}
+				onDelete={jest.fn()}
 			/>
 		);
 
@@ -58,8 +59,9 @@ describe('DownloadListItem', () => {
 	});
 
 	it('should display the menu and handle presses', () => {
-		const onPlay = jest.fn();
 		const onDelete = jest.fn();
+		const onOpen = jest.fn();
+		const onPlay = jest.fn();
 
 		model.canPlay = true;
 		model.status = DownloadStatus.Complete;
@@ -68,7 +70,8 @@ describe('DownloadListItem', () => {
 			<DownloadListItem
 				item={model}
 				index={0}
-				onSelect={() => { /* no-op */ }}
+				onSelect={jest.fn()}
+				onOpen={onOpen}
 				onPlay={onPlay}
 				onDelete={onDelete}
 			/>
@@ -90,11 +93,38 @@ describe('DownloadListItem', () => {
 		expect(queryByTestId('play_in_app')).not.toBeNull();
 		fireEvent.press(getByTestId('play_in_app'));
 		expect(onPlay).toHaveBeenCalledTimes(2);
+		// Pressing the open menu action should call onOpen
+		expect(onOpen).not.toHaveBeenCalled();
+		expect(queryByTestId('open_in_files')).not.toBeNull();
+		fireEvent.press(getByTestId('open_in_files'));
+		expect(onOpen).toHaveBeenCalled();
 		// Pressing the delete menu action should call onDelete
 		expect(onDelete).not.toHaveBeenCalled();
 		expect(queryByTestId('delete')).not.toBeNull();
 		fireEvent.press(getByTestId('delete'));
 		expect(onDelete).toHaveBeenCalled();
+	});
+
+	it('should call onOpen if the item is pressed and not playable', () => {
+		const onOpen = jest.fn();
+
+		model.status = DownloadStatus.Complete;
+
+		const { getByTestId } = render(
+			<DownloadListItem
+				item={model}
+				index={0}
+				onSelect={jest.fn()}
+				onOpen={onOpen}
+				onPlay={jest.fn()}
+				onDelete={jest.fn()}
+			/>
+		);
+
+		// Pressing the list item should call onOpen when not playable
+		expect(onOpen).not.toHaveBeenCalled();
+		fireEvent.press(getByTestId('list-item'));
+		expect(onOpen).toHaveBeenCalled();
 	});
 
 	it('should display the select checkbox and handle presses', () => {
@@ -107,7 +137,9 @@ describe('DownloadListItem', () => {
 				item={model}
 				index={0}
 				onSelect={onSelect}
-				onPlay={() => { /* no-op */ }}
+				onDelete={jest.fn()}
+				onOpen={jest.fn()}
+				onPlay={jest.fn()}
 				isEditMode={true}
 			/>
 		);
@@ -137,6 +169,7 @@ describe('DownloadListItem', () => {
 				item={model}
 				index={0}
 				onSelect={jest.fn()}
+				onOpen={jest.fn()}
 				onPlay={jest.fn()}
 				onDelete={jest.fn()}
 			/>

--- a/langs/en.json
+++ b/langs/en.json
@@ -5,6 +5,7 @@
     "delete": "Delete",
     "edit": "Edit",
     "ok": "OK",
+    "openInFiles": "Open in Files",
     "play": "Play",
     "unknown": "Unknown"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3823,6 +3823,11 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
+    "@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="
+    },
     "@types/react": {
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
@@ -5247,7 +5252,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
       "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
-      "dev": true,
       "requires": {
         "call-bind-apply-helpers": "^1.0.1",
         "get-intrinsic": "^1.2.6"
@@ -7270,6 +7274,28 @@
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-10.2.1.tgz",
       "integrity": "sha512-UBge1BwzDPhUFX0gKu9eDLwEFj4LGiqrOogNoEYxcosM1SwhkbWwPrd3zZtl53LLz02TxEi/CI/MUGJJsrVQLw==",
       "requires": {}
+    },
+    "expo-linking": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-3.2.4.tgz",
+      "integrity": "sha512-yVH72hqridgxiknuqeVs5ZClxIaEft2xyDfC9+x8pSelGb1oMnaOYY4muE9ytph6VCXbmMI9VNf0etrfFoDLqQ==",
+      "requires": {
+        "@types/qs": "^6.5.3",
+        "expo-constants": "~13.2.0",
+        "invariant": "^2.2.4",
+        "qs": "^6.9.1",
+        "url-parse": "^1.5.9"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.14.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+          "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+          "requires": {
+            "side-channel": "^1.1.0"
+          }
+        }
+      }
     },
     "expo-localization": {
       "version": "13.1.0",
@@ -11851,8 +11877,7 @@
     "object-inspect": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
-      "dev": true
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -13737,7 +13762,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "requires": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -13750,7 +13774,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "requires": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -13760,7 +13783,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "requires": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -13772,7 +13794,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "requires": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "expo-file-system": "~14.1.0",
     "expo-font": "~10.2.0",
     "expo-keep-awake": "~10.2.0",
+    "expo-linking": "~3.2.4",
     "expo-localization": "~13.1.0",
     "expo-screen-orientation": "~4.3.0",
     "expo-splash-screen": "~0.16.2",

--- a/screens/DownloadScreen.tsx
+++ b/screens/DownloadScreen.tsx
@@ -9,6 +9,7 @@
 import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import * as FileSystem from 'expo-file-system';
+import * as Linking from 'expo-linking';
 import React, { useCallback, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Alert, FlatList, StyleSheet, View } from 'react-native';
@@ -20,6 +21,7 @@ import ErrorView from '../components/ErrorView';
 import { Screens } from '../constants/Screens';
 import { useStores } from '../hooks/useStores';
 import type DownloadModel from '../models/DownloadModel';
+import { getFilesUri } from '../utils/File';
 
 const Hairline = () => <View style={{ height: StyleSheet.hairlineWidth }} />;
 
@@ -139,6 +141,11 @@ const DownloadScreen = () => {
 			isSelected={selectedItems.some(s => s.key === item.key)}
 			onSelect={() => {
 				toggleSelectedItem(item);
+			}}
+			onOpen={() => {
+				const uri = getFilesUri(item.uri);
+				console.debug('[DownloadScreen] opening uri', uri);
+				Linking.openURL(uri);
 			}}
 			onPlay={() => {
 				item.isNew = false;

--- a/utils/File.ts
+++ b/utils/File.ts
@@ -26,6 +26,11 @@ export async function ensurePathExists(path: string) {
 	}
 }
 
+/** Gets a URI to open the Files app on iOS from a direct file:// URI */
+export function getFilesUri(uri: string) {
+	return uri.replace('file://', 'shareddocuments://');
+}
+
 /** Trim and replace any invalid characters in a file/directory name (extension excluded). */
 export function sanitizeFileName(name?: string) {
 	const trimmed = name?.trim();

--- a/utils/File.ts
+++ b/utils/File.ts
@@ -28,7 +28,7 @@ export async function ensurePathExists(path: string) {
 
 /** Gets a URI to open the Files app on iOS from a direct file:// URI */
 export function getFilesUri(uri: string) {
-	return uri.replace('file://', 'shareddocuments://');
+	return uri.replace(/^file:\/\//, 'shareddocuments://');
 }
 
 /** Trim and replace any invalid characters in a file/directory name (extension excluded). */

--- a/utils/__tests__/File.test.js
+++ b/utils/__tests__/File.test.js
@@ -6,7 +6,7 @@
 
 import { getInfoAsync, makeDirectoryAsync } from 'expo-file-system';
 
-import { ensurePathExists, sanitizeFileName } from '../File';
+import { ensurePathExists, getFilesUri, sanitizeFileName } from '../File';
 
 jest.mock('expo-file-system');
 
@@ -34,6 +34,12 @@ describe('File', () => {
 
 			expect(getInfoAsync).toHaveBeenCalled();
 			expect(makeDirectoryAsync).toHaveBeenCalled();
+		});
+	});
+
+	describe('getFilesUri', () => {
+		it('should get a valid Files app uri', () => {
+			expect(getFilesUri('file://foobar')).toBe('shareddocuments://foobar');
 		});
 	});
 


### PR DESCRIPTION
Adds support for opening downloads in the files app directly from the downloads tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Open in Files” action for downloaded items; tapping a completed item now opens it when not playable in-app.
  - Status indicator menu includes “Open in Files” and triggers the same action.
  - Added localization entry for the new menu label.

- **Tests**
  - Expanded tests to cover the new open behavior via list item and menu action.

- **Chores**
  - Added a linking dependency to support external file opening.
  - Updated automation config to ignore updates for that linking package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->