### PR TITLE
Allow editing failed downloads

### DIFF
--- a/features/downloads/components/DownloadListItem.tsx
+++ b/features/downloads/components/DownloadListItem.tsx
@@ -53,7 +53,11 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 			testID='list-item'
 			topDivider={index === 0}
 			bottomDivider
-			onPress={item.status === DownloadStatus.Complete ? onItemPress : undefined}
+			onPress={
+				((isEditMode && item.isComplete) || item.status === DownloadStatus.Complete)
+					? onItemPress
+					: undefined
+			}
 		>
 			{isEditMode &&
 				<ListItem.CheckBox

--- a/features/downloads/components/DownloadListItem.tsx
+++ b/features/downloads/components/DownloadListItem.tsx
@@ -12,6 +12,7 @@ import { ListItem } from 'react-native-elements';
 import type DownloadModel from '../../../models/DownloadModel';
 import { getItemSubtitle } from '../../../utils/baseItem';
 import type { DownloadAction } from '../constants/DownloadAction';
+import { DownloadStatus } from '../constants/DownloadStatus';
 import type { DownloadItemAction } from '../types/downloadItemAction';
 
 import DownloadStatusIndicator from './DownloadStatusIndicator';
@@ -52,7 +53,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 			testID='list-item'
 			topDivider={index === 0}
 			bottomDivider
-			onPress={item.isComplete ? onItemPress : undefined}
+			onPress={item.status === DownloadStatus.Complete ? onItemPress : undefined}
 		>
 			{isEditMode &&
 				<ListItem.CheckBox

--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -30,6 +30,11 @@ interface MobxDownloadModel {
 	isNew: boolean;
 }
 
+const COMPLETE_STATUSES: DownloadStatus[] = [
+	DownloadStatus.Complete,
+	DownloadStatus.Failed
+];
+
 const DOWNLOADS_DIRECTORY = 'Downloads/';
 
 export default class DownloadModel {
@@ -68,7 +73,7 @@ export default class DownloadModel {
 	}
 
 	get isComplete() {
-		return this.status === DownloadStatus.Complete;
+		return COMPLETE_STATUSES.includes(this.status);
 	}
 
 	/**


### PR DESCRIPTION
Allows failed downloads to be deleted in edit mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of when a download is considered complete (now treats additional terminal states as complete), fixing edge cases that led to incorrect status behavior.
  * Download list items now respond consistently to taps based on status and edit mode, improving interaction reliability.

* **Refactor**
  * Streamlined internal logic for determining download completion to ensure consistent behavior across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->