### PR TITLE
Bump build number to 1.7.0.6

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
       "**/*"
     ],
     "ios": {
-      "buildNumber": "1.7.0.5",
+      "buildNumber": "1.7.0.6",
       "supportsTablet": true,
       "requireFullScreen": false,
       "bundleIdentifier": "org.jellyfin.expo",

--- a/ios/Jellyfin/Info.plist
+++ b/ios/Jellyfin/Info.plist
@@ -30,7 +30,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.7.0.5</string>
+    <string>1.7.0.6</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>LSSupportsOpeningDocumentsInPlace</key>


### PR DESCRIPTION
Bumps the build number to 1.7.0.6 for the next TestFlight release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the iOS build number to 1.7.0.6 across app configuration and iOS bundle metadata.
  * Ensures consistent versioning for TestFlight/App Store distribution and clearer release tracking.
  * No user-facing changes or behavior impacts; functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->