### PR TITLE
Add handling of downloads removed from the file system

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -98,6 +98,10 @@
         "title": "Download Failed",
         "description": "\"{{title}}\" failed to download."
     },
+    "missingDownload": {
+        "title": "Missing Download",
+        "description": "This download seems to have been removed outside the Jellyfin app."
+    },
     "resetApplication": {
       "title": "Reset Application",
       "description": "Are you sure you want to reset all settings?",

--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -30,9 +30,11 @@ interface MobxDownloadModel {
 	isNew: boolean;
 }
 
+/** Statuses that a finished download can be in. */
 const COMPLETE_STATUSES: DownloadStatus[] = [
 	DownloadStatus.Complete,
-	DownloadStatus.Failed
+	DownloadStatus.Failed,
+	DownloadStatus.Missing
 ];
 
 const DOWNLOADS_DIRECTORY = 'Downloads/';


### PR DESCRIPTION
Adds a check and user messaging for downloads that have been removed from the file system outside of the Jellyfin app (i.e. the Files app)

Fixes #728 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app alert for missing downloads, informing users when a file was removed outside the app.
  * Introduced a “Missing” status for downloads, clearly indicating items whose files are no longer present.

* **Bug Fixes**
  * The app now checks for file existence before performing download actions, preventing errors on removed files.
  * Missing downloads are handled gracefully: status is updated, the list reflects the change, and actions are safely halted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->