### PR TITLE
Add deletion of download subdirectories

### DIFF
--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -95,6 +95,7 @@ export default class DownloadModel {
 		return `${this.item.ServerId}_${this.item.Id}`;
 	}
 
+	/** Returns the downloads filename. */
 	get localFilename() {
 		let ext = this.extension;
 		// If no extension override is set, try to get the original from the item.Path
@@ -115,21 +116,28 @@ export default class DownloadModel {
 		return this.filename.slice(0, this.filename.lastIndexOf('.')) + '.mp4';
 	}
 
+	/** Returns the absolute directory path. */
 	get localPath() {
+		return `${FileSystem.documentDirectory}${this.relativePath}`;
+	}
+
+	/** Returns the URI encoded absolute directory path. */
+	get localPathUri() {
+		return encodeURI(this.localPath);
+	}
+
+	/** Returns the relative directory path (document directory should be the base). */
+	get relativePath() {
 		// Legacy downloads will not have a path set
 		if (this.item.Path) {
 			const itemDirectory = getItemDirectory(this.item);
 			if (itemDirectory) {
-				return `${FileSystem.documentDirectory}${DOWNLOADS_DIRECTORY}${itemDirectory}`;
+				return `${DOWNLOADS_DIRECTORY}${itemDirectory}`;
 			}
 		}
 
 		// Fallback for legacy downloads
-		return `${FileSystem.documentDirectory}${this.item.ServerId}/${this.item.Id}/`;
-	}
-
-	get localPathUri() {
-		return encodeURI(this.localPath);
+		return `${this.item.ServerId}/${this.item.Id}/`;
 	}
 
 	/** @deprecated Use item.ServerId instead. */
@@ -141,6 +149,7 @@ export default class DownloadModel {
 		return this.item.Name || undefined;
 	}
 
+	/** Returns the URI encoded absolute file path. */
 	get uri() {
 		return encodeURI(this.localPath + this.localFilename);
 	}


### PR DESCRIPTION
Adds deletion of empty subdirectories for downloads

Fixes #725 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a download now reliably removes the file and cleans up any empty parent folders, without touching directories that still contain other items.
  * Reduces leftover empty folders after removing downloads.

* **Refactor**
  * Centralized and standardized path handling for downloads, improving consistency of file names, locations, and URIs.
  * More predictable storage behavior across different download scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->