### PR TITLE
Mark transcoded downloads as alpha

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "alpha": "ALPHA",
     "beta": "BETA",
     "cancel": "Cancel",
     "delete": "Delete",

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -214,7 +214,8 @@ const SettingsScreen = () => {
 					key: 'experimental-downloads-switch',
 					title: t('settings.downloadTranscoding'),
 					badge: {
-						value: t('common.beta')
+						value: t('common.alpha'),
+						status: 'warning'
 					},
 					value: settingStore.isExperimentalDownloadsEnabled,
 					onValueChange: (value) => {

--- a/themes/base/elements.js
+++ b/themes/base/elements.js
@@ -21,6 +21,9 @@ export default {
 	Badge: {
 		badgeStyle: {
 			borderWidth: 0
+		},
+		textStyle: {
+			color: Colors.black
 		}
 	},
 	Input: {


### PR DESCRIPTION
* Tags transcoded downloads as alpha instead of beta.
* Fixes readability issue with badges using white text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the experimental downloads badge in Settings from “BETA” to “ALPHA” with a warning status for clearer visual signaling.
  * Improved badge readability by applying a black text color in the theme.

* **Chores**
  * Added a new translation key for “ALPHA” to support the updated labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->