### PR TITLE
Fix native playback positions

### DIFF
--- a/components/AudioPlayer.js
+++ b/components/AudioPlayer.js
@@ -75,7 +75,7 @@ const AudioPlayer = () => {
 		if (mediaStore.type === MediaType.Audio) {
 			createPlayer({
 				uri: mediaStore.uri,
-				positionMillis: mediaStore.positionMillis
+				positionMillis: mediaStore.getPositionMillis()
 			});
 		}
 	}, [ mediaStore.type, mediaStore.uri ]);

--- a/components/VideoPlayer.js
+++ b/components/VideoPlayer.js
@@ -38,7 +38,7 @@ const VideoPlayer = () => {
 			player.current?.loadAsync({
 				uri: mediaStore.uri
 			}, {
-				positionMillis: mediaStore.positionMillis,
+				positionMillis: mediaStore.getPositionMillis(),
 				shouldPlay: true
 			});
 		}

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -69,7 +69,7 @@ const HomeScreen = () => {
 				isFinished: mediaStore.isFinished,
 				isPlaying: mediaStore.isPlaying,
 				positionTicks: mediaStore.positionTicks,
-				positionMillis: mediaStore.positionMillis
+				positionMillis: mediaStore.getPositionMillis()
 			};
 
 			if (mediaStore.type === MediaType.Audio) {


### PR DESCRIPTION
Fix invalid references to `mediaStore.positionMillis` that caused issues with playback position in native players

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized how playback position is retrieved across Audio Player, Video Player, and Home screen status updates by using a getter method.
  - Improves consistency and stability of resume position handling without changing visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->