### PR TITLE
Fix photo downloads using artist name

### DIFF
--- a/utils/__tests__/baseItem.test.js
+++ b/utils/__tests__/baseItem.test.js
@@ -6,6 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models';
+
 import { getItemDirectory, getItemFileName, getItemSubtitle } from '../baseItem';
 
 describe('getItemSubtitle', () => {
@@ -66,6 +68,21 @@ describe('getItemDirectory', () => {
 		item.Album = '  ** ';
 		item.AlbumArtist = ':?\\';
 		expect(getItemDirectory(item)).toBe('Unknown Artist/Unknown Album/');
+	});
+
+	it('should handle photos correctly', () => {
+		const item = {
+			Album: 'Album Name',
+			Type: BaseItemKind.Photo
+		};
+		expect(getItemDirectory(item)).toBe('Album Name/');
+
+		item.AlbumArtist = 'Ozzy Osbourne';
+		expect(getItemDirectory(item)).toBe('Album Name/');
+
+		item.Album = '  ** ';
+		item.AlbumArtist = ':?\\';
+		expect(getItemDirectory(item)).toBe('Unknown Album/');
 	});
 
 	it('should handle episodes correctly', () => {

--- a/utils/baseItem.ts
+++ b/utils/baseItem.ts
@@ -7,8 +7,14 @@
  */
 
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
+import { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind';
 
 import { sanitizeFileName } from './File';
+
+const NO_ARTIST_TYPES: BaseItemKind[] = [
+	BaseItemKind.Photo,
+	BaseItemKind.Video
+];
 
 /** Gets the short episode ID for display. e.g. S2E5-6 */
 const getShortEpisodeId = (item: BaseItemDto): string | undefined => {
@@ -62,12 +68,15 @@ export const getItemSubtitle = (item: BaseItemDto): string | undefined => {
  * Gets the directory path that an item should be saved under.
  */
 export const getItemDirectory = (item: BaseItemDto): string | undefined => {
-	// Songs will use: Artist Name/Album Name/
-	// NOTE: It would be better to separate by Disc but we have no way of identifying songs from multi-disc albums
-	// from the BaseItem of the song.
 	if (item.Album) {
-		const artist = sanitizeFileName(item.AlbumArtist || undefined) || 'Unknown Artist';
+		// Photos or Home Videos will use: Album Name/
 		const album = sanitizeFileName(item.Album) || 'Unknown Album';
+		if (item.Type && NO_ARTIST_TYPES.includes(item.Type)) return `${album}/`;
+
+		// Songs or Music Videos will use: Artist Name/Album Name/
+		// NOTE: It would be better to separate by Disc but we have no way of identifying songs from multi-disc albums
+		// from the BaseItem of the song.
+		const artist = sanitizeFileName(item.AlbumArtist || undefined) || 'Unknown Artist';
 		return `${artist}/${album}/`;
 	}
 


### PR DESCRIPTION
Fixes photos and home videos being stored under "Unknown Aritst" because Album is also used for photo albums

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Photos and home videos are now organized by Album when generating directories, improving library structure.
  - Consistent fallback to “Unknown Album/” when Album is missing or whitespace.

- Bug Fixes
  - Corrected directory pathing for photo-type items that were previously placed under Artist/Album.

- Tests
  - Added tests covering photo items to validate Album-based directory behavior and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->