### PR TITLE
Fix canPlay logic for legacy downloads

### DIFF
--- a/features/downloads/utils/downloadItemActions.ts
+++ b/features/downloads/utils/downloadItemActions.ts
@@ -15,7 +15,10 @@ import type { DownloadItemAction } from '../types/downloadItemAction';
 export const getDownloadItemActions = (download: DownloadModel): DownloadItemAction[] => {
 	// NOTE: Currently only video has a native UI to play within the app.
 	// The media type check should be removed when we have a native audio player UI available.
-	const isPlayableInApp = download.canPlay && download.item.MediaType === MediaType.Video;
+	const isPlayableInApp = download.canPlay && (
+		!download.item.MediaType || // Legacy downloads won't have a MediaType set but are playable
+		download.item.MediaType === MediaType.Video
+	);
 
 	return [
 		{

--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -7,6 +7,7 @@
  */
 
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto';
+import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import * as FileSystem from 'expo-file-system';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -175,7 +176,8 @@ export function fromStorageObject({
 		{
 			Id: itemId,
 			ServerId: serverId,
-			Name: title
+			Name: title,
+			MediaType: MediaType.Video
 		},
 		serverUrl,
 		apiKey,

--- a/models/__tests__/DownloadModel.test.js
+++ b/models/__tests__/DownloadModel.test.js
@@ -4,6 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
+
 import { DownloadStatus } from '../../features/downloads/constants/DownloadStatus';
 import DownloadModel, { fromStorageObject } from '../DownloadModel';
 
@@ -141,5 +143,9 @@ describe('DownloadModel', () => {
 		expect(download.isComplete).toBe(value.isComplete);
 		expect(download.isNew).toBe(value.isNew);
 		expect(download.canPlay).toBe(true);
+		expect(download.item.Id).toBe(value.itemId);
+		expect(download.item.ServerId).toBe(value.serverId);
+		expect(download.item.Name).toBe(value.title);
+		expect(download.item.MediaType).toBe(MediaType.Video);
 	});
 });


### PR DESCRIPTION
Fixes a small regression preventing legacy downloads from playing in app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded “Play in App” to include eligible legacy downloads that lack media type metadata, increasing playable coverage.

* **Bug Fixes**
  * Correctly recognizes downloaded videos without media type tags as playable when supported, improving consistency of in-app playback options across downloads and library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->