### PR TITLE
Bump version for 1.8.0.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
 fund=false
+git-tag-version=false
 lockfile-version=1
 save-exact=true

--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "platforms": [
       "ios"
     ],
-    "version": "1.7.0",
+    "version": "1.8.0",
     "orientation": "default",
     "primaryColor": "#00a4dc",
     "backgroundColor": "#101010",
@@ -26,7 +26,7 @@
       "**/*"
     ],
     "ios": {
-      "buildNumber": "1.7.0.9",
+      "buildNumber": "1.8.0.0",
       "supportsTablet": true,
       "requireFullScreen": false,
       "bundleIdentifier": "org.jellyfin.expo",

--- a/ios/Jellyfin/Info.plist
+++ b/ios/Jellyfin/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.7.0</string>
+    <string>1.8.0</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -30,7 +30,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.7.0.9</string>
+    <string>1.8.0.0</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>LSSupportsOpeningDocumentsInPlace</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-ios",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-ios",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",


### PR DESCRIPTION
Bumps versions for 1.8.0 since we cannot publish any new 1.7 releases to TestFlight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.8.0 across package manifests and iOS build configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->