### PR TITLE
Prefer in-app playback for local video downloads

### DIFF
--- a/features/downloads/components/__tests__/DownloadListItem.test.js
+++ b/features/downloads/components/__tests__/DownloadListItem.test.js
@@ -101,6 +101,39 @@ describe('DownloadListItem', () => {
 
 	it('should call onOpen if the item is pressed and not playable', () => {
 		const onAction = jest.fn();
+		const audioModel = new DownloadModel(
+			{
+				Id: 'item-id',
+				ServerId: 'server-id',
+				Name: 'title',
+				MediaType: MediaType.Audio
+			},
+			'https://example.com/',
+			'api-key',
+			'file name.mp3',
+			'https://example.com/download'
+		);
+
+		audioModel.status = DownloadStatus.Complete;
+
+		const { getByTestId } = render(
+			<DownloadListItem
+				item={audioModel}
+				index={0}
+				actions={getDownloadItemActions(audioModel)}
+				onAction={onAction}
+				onSelect={jest.fn()}
+			/>
+		);
+
+		// Pressing the list item should call onOpen when not playable
+		expect(onAction).not.toHaveBeenCalled();
+		fireEvent.press(getByTestId('list-item'));
+		expect(onAction).toHaveBeenCalledWith(DownloadAction.OpenInFiles);
+	});
+
+	it('should call onPlay for completed video downloads even without canPlay metadata', () => {
+		const onAction = jest.fn();
 
 		model.status = DownloadStatus.Complete;
 
@@ -114,10 +147,9 @@ describe('DownloadListItem', () => {
 			/>
 		);
 
-		// Pressing the list item should call onOpen when not playable
 		expect(onAction).not.toHaveBeenCalled();
 		fireEvent.press(getByTestId('list-item'));
-		expect(onAction).toHaveBeenCalledWith(DownloadAction.OpenInFiles);
+		expect(onAction).toHaveBeenCalledWith(DownloadAction.PlayInApp);
 	});
 
 	it('should display the select checkbox and handle presses', () => {

--- a/features/downloads/utils/downloadItemActions.ts
+++ b/features/downloads/utils/downloadItemActions.ts
@@ -10,15 +10,16 @@ import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type'
 
 import type DownloadModel from '../../../models/DownloadModel';
 import { DownloadAction } from '../constants/DownloadAction';
+import { DownloadStatus } from '../constants/DownloadStatus';
 import type { DownloadItemAction } from '../types/downloadItemAction';
 
 export const getDownloadItemActions = (download: DownloadModel): DownloadItemAction[] => {
 	// NOTE: Currently only video has a native UI to play within the app.
 	// The media type check should be removed when we have a native audio player UI available.
-	const isPlayableInApp = download.canPlay && (
+	const isVideoDownload =
 		!download.item.MediaType || // Legacy downloads won't have a MediaType set but are playable
-		download.item.MediaType === MediaType.Video
-	);
+		download.item.MediaType === MediaType.Video;
+	const isPlayableInApp = (download.canPlay || download.status === DownloadStatus.Complete) && isVideoDownload;
 
 	return [
 		{


### PR DESCRIPTION
Partly addresses #750. This changes completed local video downloads to prefer Jellyfin's in-app playback path even when the earlier server metadata step did not mark the file as playable, which prevents valid offline downloads from defaulting to Files or VLC unnecessarily. It keeps the existing external-file fallback available, narrows the change to completed video downloads only, and adds test coverage for both the in-app video case and the still-external audio case.