### PR TITLE
Show progress bar and download speed when downloading content

### DIFF
--- a/features/downloads/components/DownloadListItem.tsx
+++ b/features/downloads/components/DownloadListItem.tsx
@@ -6,15 +6,25 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useMemo, type FC } from 'react';
-import { ListItem } from 'react-native-elements';
+import React, { useCallback, useMemo, useContext, type FC } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { ListItem, ThemeContext } from 'react-native-elements';
 
 import type DownloadModel from '../../../models/DownloadModel';
 import { getItemSubtitle } from '../../../utils/baseItem';
 import type { DownloadAction } from '../constants/DownloadAction';
+import { DownloadStatus } from '../constants/DownloadStatus';
 import type { DownloadItemAction } from '../types/downloadItemAction';
 
 import DownloadStatusIndicator from './DownloadStatusIndicator';
+
+const formatSpeed = (bytesPerSec: number): string => {
+	if (bytesPerSec <= 0) return '0 B/s';
+	const units = ['B/s', 'KB/s', 'MB/s', 'GB/s'];
+	const index = Math.min(Math.floor(Math.log(bytesPerSec) / Math.log(1024)), units.length - 1);
+	const speed = bytesPerSec / Math.pow(1024, index);
+	return `${speed.toFixed(1)} ${units[index]}`;
+};
 
 interface DownloadListItemProps {
 	item: DownloadModel;
@@ -35,6 +45,7 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 	isEditMode = false,
 	isSelected = false
 }) => {
+	const { theme } = useContext(ThemeContext);
 	const subtitle = useMemo(() => getItemSubtitle(item.item), [ item.item ]);
 
 	const onItemPress = useCallback(() => {
@@ -79,6 +90,32 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 				>
 					{subtitle || item.localFilename}
 				</ListItem.Subtitle>
+				{item.status === DownloadStatus.Downloading && (
+					<View style={styles.progressContainer} testID='progress-container'>
+						<View style={[styles.progressBarTrack, { backgroundColor: theme.colors?.grey5 || '#e0e0e0' }]}>
+							<View
+								testID='progress-bar-fill'
+								style={[
+									styles.progressBarFill,
+									{
+										width: `${Math.min(Math.max(item.progress || 0, 0), 1) * 100}%`,
+										backgroundColor: theme.colors?.primary || '#00a4dc'
+									}
+								]}
+							/>
+						</View>
+						<View style={styles.progressTextContainer}>
+							<Text style={[styles.progressText, { color: theme.colors?.grey3 || '#757575' }]} testID='progress-percent'>
+								{`${((item.progress || 0) * 100).toFixed(0)}%`}
+							</Text>
+							{typeof item.speed === 'number' && item.speed > 0 && (
+								<Text style={[styles.progressText, { color: theme.colors?.grey3 || '#757575' }]} testID='progress-speed'>
+									{formatSpeed(item.speed)}
+								</Text>
+							)}
+						</View>
+					</View>
+				)}
 			</ListItem.Content>
 
 			<DownloadStatusIndicator
@@ -90,6 +127,30 @@ const DownloadListItem: FC<DownloadListItemProps> = ({
 		</ListItem>
 	);
 };
+
+const styles = StyleSheet.create({
+	progressContainer: {
+		width: '100%',
+		marginTop: 8
+	},
+	progressBarTrack: {
+		height: 4,
+		width: '100%',
+		borderRadius: 2,
+		overflow: 'hidden',
+		marginBottom: 4
+	},
+	progressBarFill: {
+		height: '100%'
+	},
+	progressTextContainer: {
+		flexDirection: 'row',
+		justifyContent: 'space-between'
+	},
+	progressText: {
+		fontSize: 12
+	}
+});
 
 DownloadListItem.displayName = 'DownloadListItem';
 export default DownloadListItem;

--- a/features/downloads/components/__tests__/DownloadListItem.test.js
+++ b/features/downloads/components/__tests__/DownloadListItem.test.js
@@ -54,6 +54,29 @@ describe('DownloadListItem', () => {
 		expect(getByTestId('subtitle')).toHaveTextContent('file name.mp4');
 
 		expect(queryByTestId('loading-indicator')).not.toBeNull();
+		expect(getByTestId('progress-container')).not.toBeNull();
+		expect(getByTestId('progress-percent')).toHaveTextContent('0%');
+		expect(queryByTestId('progress-speed')).toBeNull();
+	});
+
+	it('should render progress percent and speed correctly when downloading', () => {
+		model.status = DownloadStatus.Downloading;
+		model.progress = 0.684;
+		model.speed = 1024 * 1024 * 3.4; // 3.4 MB/s
+
+		const { getByTestId, queryByTestId } = render(
+			<DownloadListItem
+				item={model}
+				index={0}
+				actions={getDownloadItemActions(model)}
+				onAction={jest.fn()}
+				onSelect={jest.fn()}
+			/>
+		);
+
+		expect(getByTestId('progress-container')).not.toBeNull();
+		expect(getByTestId('progress-percent')).toHaveTextContent('68%');
+		expect(getByTestId('progress-speed')).toHaveTextContent('3.4 MB/s');
 	});
 
 	it('should display the menu and handle presses', () => {

--- a/features/downloads/hooks/useDownloadHandler.ts
+++ b/features/downloads/hooks/useDownloadHandler.ts
@@ -110,6 +110,8 @@ export const useDownloadHandler = (enabled = false) => {
 		try {
 			// Update the status
 			download.status = DownloadStatus.Downloading;
+			download.progress = 0;
+			download.speed = 0;
 			downloadStore.update(download);
 
 			// Create the download folder if it doesn't exist
@@ -139,13 +141,32 @@ export const useDownloadHandler = (enabled = false) => {
 
 			console.debug('[useDownloadHandler] downloading from url', downloadMetadata.url);
 
+			let lastUpdateTime = Date.now();
+			let lastBytesWritten = 0;
+
 			const resumable = FileSystem.createDownloadResumable(
 				downloadMetadata.url.toString(),
 				download.uri,
 				{},
-				(/*{ totalBytesWritten }*/) => {
-					// FIXME: We should save the download progress in the model for display
-					// but this needs throttling
+				({ totalBytesWritten, totalBytesExpectedToWrite }) => {
+					const now = Date.now();
+					const duration = now - lastUpdateTime;
+
+					// Throttle updates to at least 500ms or when complete
+					const isFinished = totalBytesWritten === totalBytesExpectedToWrite;
+					if (duration >= 500 || isFinished) {
+						const progress = totalBytesExpectedToWrite > 0 ? totalBytesWritten / totalBytesExpectedToWrite : 0;
+						const bytesDelta = totalBytesWritten - lastBytesWritten;
+						const timeDeltaSecs = duration / 1000;
+						const speed = timeDeltaSecs > 0 ? bytesDelta / timeDeltaSecs : 0;
+
+						download.progress = progress;
+						download.speed = speed;
+						downloadStore.update(download);
+
+						lastUpdateTime = now;
+						lastBytesWritten = totalBytesWritten;
+					}
 				}
 			);
 
@@ -177,6 +198,8 @@ export const useDownloadHandler = (enabled = false) => {
 
 			download.status = DownloadStatus.Failed;
 		} finally {
+			download.progress = undefined;
+			download.speed = undefined;
 			// Push the state update to the store
 			downloadStore.update(download);
 		}

--- a/models/DownloadModel.ts
+++ b/models/DownloadModel.ts
@@ -44,6 +44,8 @@ export default class DownloadModel {
 	status: DownloadStatus = DownloadStatus.Pending
 	isNew = true
 	canPlay = false
+	progress?: number
+	speed?: number
 
 	apiKey: string
 	readonly item: Readonly<DownloadItem>


### PR DESCRIPTION
Implement a download progress bar and speed display under downloading items. Updates are throttled to every 500ms for performance.