### PR TITLE
Enable background media playback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ node_modules/**/*
 .expo/*
 .expo-shared/*
 npm-debug.*
+
+# OS/editor files
+.DS_Store
+.idea/
+*.iml
+
 *.jks
 *.p12
 *.key

--- a/components/AudioPlayer.js
+++ b/components/AudioPlayer.js
@@ -27,7 +27,7 @@ const AudioPlayer = () => {
 			shouldDuckAndroid: true,
 			interruptionModeIOS: InterruptionModeIOS.DoNotMix,
 			playsInSilentModeIOS: true
-		});
+		}).catch(console.warn);
 
 		return () => {
 			player?.stopAsync();

--- a/components/VideoPlayer.js
+++ b/components/VideoPlayer.js
@@ -9,7 +9,7 @@
 import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { Audio, InterruptionModeAndroid, InterruptionModeIOS, Video, VideoFullscreenUpdate } from 'expo-av';
 import React, { useEffect, useRef, useState } from 'react';
-import { Alert } from 'react-native';
+import { Alert, AppState } from 'react-native';
 
 import { useStores } from '../hooks/useStores';
 import { msToTicks } from '../utils/Time';
@@ -18,18 +18,60 @@ const VideoPlayer = () => {
 	const { rootStore, mediaStore } = useStores();
 
 	const player = useRef(null);
+	const appState = useRef(AppState.currentState);
+	const shouldRestoreFullscreen = useRef(false);
 	// Local player fullscreen state
 	const [ isPresenting, setIsPresenting ] = useState(false);
 	const [ isDismissing, setIsDismissing ] = useState(false);
 
+	const openFullscreen = () => {
+		if (!isPresenting) {
+			player.current?.presentFullscreenPlayer()
+				.catch(e => {
+					console.error(e);
+					Alert.alert(e);
+				});
+		}
+	};
+
+	const closeFullscreen = () => {
+		if (!isDismissing) {
+			player.current?.dismissFullscreenPlayer()
+				.catch(e => {
+					console.debug(e);
+				});
+		}
+	};
+
 	// Set the audio mode when the video player is created
 	useEffect(() => {
 		Audio.setAudioModeAsync({
+			staysActiveInBackground: true,
 			interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
 			interruptionModeIOS: InterruptionModeIOS.DoNotMix,
 			playsInSilentModeIOS: true
-		});
+		}).catch(console.warn);
 	}, []);
+
+	useEffect(() => {
+		const subscription = AppState.addEventListener('change', nextAppState => {
+			const wasBackgrounded = appState.current !== 'active';
+			appState.current = nextAppState;
+
+			if (
+				wasBackgrounded &&
+				nextAppState === 'active' &&
+				shouldRestoreFullscreen.current &&
+				mediaStore.type === MediaType.Video &&
+				mediaStore.uri
+			) {
+				shouldRestoreFullscreen.current = false;
+				openFullscreen();
+			}
+		});
+
+		return () => subscription.remove();
+	}, [ mediaStore.type, mediaStore.uri ]);
 
 	// Update the player when media type or uri changes
 	useEffect(() => {
@@ -65,25 +107,6 @@ const VideoPlayer = () => {
 		}
 	}, [ mediaStore.shouldStop ]);
 
-	const openFullscreen = () => {
-		if (!isPresenting) {
-			player.current?.presentFullscreenPlayer()
-				.catch(e => {
-					console.error(e);
-					Alert.alert(e);
-				});
-		}
-	};
-
-	const closeFullscreen = () => {
-		if (!isDismissing) {
-			player.current?.dismissFullscreenPlayer()
-				.catch(e => {
-					console.debug(e);
-				});
-		}
-	};
-
 	return (
 		<Video
 			ref={player}
@@ -114,10 +137,17 @@ const VideoPlayer = () => {
 						break;
 					case VideoFullscreenUpdate.PLAYER_WILL_DISMISS:
 						setIsDismissing(true);
+						if (appState.current !== 'active') {
+							shouldRestoreFullscreen.current = true;
+						}
 						break;
 					case VideoFullscreenUpdate.PLAYER_DID_DISMISS:
 						setIsDismissing(false);
 						rootStore.set({ isFullscreen: false });
+						// Locking or backgrounding can dismiss fullscreen without meaning playback should stop.
+						if (appState.current !== 'active' || shouldRestoreFullscreen.current) {
+							break;
+						}
 						mediaStore.reset();
 						player.current?.unloadAsync()
 							.catch(console.debug);

--- a/ios/Jellyfin/AppDelegate.mm
+++ b/ios/Jellyfin/AppDelegate.mm
@@ -8,6 +8,8 @@
 
 #import <React/RCTAppSetupUtils.h>
 
+#import <AVFoundation/AVFoundation.h>
+
 #if RCT_NEW_ARCH_ENABLED
 #import <React/CoreModulesPlugins.h>
 #import <React/RCTCxxBridgeDelegate.h>
@@ -34,6 +36,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   RCTAppSetupPrepareApp(application);
+  [self configureAudioSession];
 
   RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
 
@@ -58,6 +61,15 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
   [super application:application didFinishLaunchingWithOptions:launchOptions];
 
   return YES;
+}
+
+- (void)configureAudioSession
+{
+  NSError *categoryError = nil;
+  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&categoryError];
+  if (categoryError) {
+    NSLog(@"Failed to set audio session category: %@", categoryError);
+  }
 }
 
 - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge

--- a/stores/SettingStore.ts
+++ b/stores/SettingStore.ts
@@ -73,7 +73,7 @@ const initialState: () => State = () => ({
 	isSystemThemeEnabled: false,
 	isNativeVideoPlayerEnabled: false,
 	isFmp4Enabled: true,
-	isExperimentalNativeAudioPlayerEnabled: false,
+	isExperimentalNativeAudioPlayerEnabled: Platform.OS === 'ios',
 	isExperimentalDownloadsEnabled: false,
 	systemThemeId: null
 });
@@ -105,7 +105,14 @@ export const useSettingStore = create<SettingStore>()(
 				}
 			}), {
 				name: STORE_NAME,
+				version: 1,
 				storage: createJSONStorage(() => AsyncStorage),
+				migrate: (persistedState, version) => ({
+					...(persistedState as State),
+					...(version < 1 && {
+						isExperimentalNativeAudioPlayerEnabled: Platform.OS === 'ios'
+					})
+				}),
 				partialize: (state) => Object.fromEntries(
 					Object.entries(state).filter(([ key ]) => persistKeys.includes(key))
 				)

--- a/stores/__tests__/SettingStore.test.js
+++ b/stores/__tests__/SettingStore.test.js
@@ -35,6 +35,7 @@ describe('SettingStore', () => {
 		expect(store.result.current.getTheme()).toBe(Themes.dark);
 		expect(store.result.current.isNativeVideoPlayerEnabled).toBe(false);
 		expect(store.result.current.isFmp4Enabled).toBe(true);
+		expect(store.result.current.isExperimentalNativeAudioPlayerEnabled).toBe(true);
 		expect(store.result.current.isExperimentalDownloadsEnabled).toBe(false);
 
 		act(store.unmount);
@@ -133,6 +134,7 @@ describe('SettingStore', () => {
 				isSystemThemeEnabled: true,
 				isNativeVideoPlayerEnabled: true,
 				isFmp4Enabled: false,
+				isExperimentalNativeAudioPlayerEnabled: false,
 				isExperimentalDownloadsEnabled: true
 			});
 		});
@@ -147,6 +149,7 @@ describe('SettingStore', () => {
 		expect(store.result.current.getTheme()).toBe(Themes.dark);
 		expect(store.result.current.isNativeVideoPlayerEnabled).toBe(true);
 		expect(store.result.current.isFmp4Enabled).toBe(false);
+		expect(store.result.current.isExperimentalNativeAudioPlayerEnabled).toBe(false);
 		expect(store.result.current.isExperimentalDownloadsEnabled).toBe(true);
 
 		act(() => {
@@ -163,6 +166,7 @@ describe('SettingStore', () => {
 		expect(store.result.current.getTheme()).toBe(Themes.dark);
 		expect(store.result.current.isNativeVideoPlayerEnabled).toBe(false);
 		expect(store.result.current.isFmp4Enabled).toBe(true);
+		expect(store.result.current.isExperimentalNativeAudioPlayerEnabled).toBe(true);
 		expect(store.result.current.isExperimentalDownloadsEnabled).toBe(false);
 	});
 });


### PR DESCRIPTION
### Changes

Enable audio and video playback to continue when the app enters the background or the iPhone is locked. Configure the native iOS audio session for playback, keep Expo AV active in the background, and prevent video playback from being unloaded during background transitions. Enable the native audio player by default on iOS and include the corresponding settings migration and tests.

Automated tests, TypeScript checks, and an iOS simulator build pass. Physical-device lock-screen testing was blocked by local Apple provisioning.

### Issues

No linked issue.

### Code assistance

OpenAI Codex was used to inspect the codebase, implement the background-playback changes, update tests, and debug the local iOS build environment. The generated changes were reviewed and verified with automated tests and an iOS simulator build.