### PR TITLE
Update axios and @jellyfin/sdk to latest versions

### DIFF
--- a/features/downloads/hooks/useDownloadHandler.ts
+++ b/features/downloads/hooks/useDownloadHandler.ts
@@ -9,7 +9,7 @@
 import type { Api } from '@jellyfin/sdk/lib/api';
 import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
 import { getMediaInfoApi } from '@jellyfin/sdk/lib/utils/api/media-info-api';
-import { getPlaystateApi } from '@jellyfin/sdk/lib/utils/api/playstate-api';
+import { getSessionApi } from '@jellyfin/sdk/lib/utils/api/session-api';
 import * as FileSystem from 'expo-file-system';
 import { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -156,7 +156,7 @@ export const useDownloadHandler = (enabled = false) => {
 			// Report transcoding download has stopped so the server will cleanup temp files
 			if (downloadMetadata.isTranscoding) {
 				console.debug('[useDownloadHandler] Reporting transcoding download stopped', download.sessionId);
-				await getPlaystateApi(api)
+				await getSessionApi(api)
 					.reportPlaybackStopped({
 						playbackStopInfo: {
 							ItemId: download.item.Id,

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,4 +1,6 @@
 /**
+ * Copyright (c) 2026 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -7,7 +9,13 @@ const { getDefaultConfig } = require('expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
 
+// We use `staticjs` assets for js files that are injected into the webview.
 defaultConfig.resolver.assetExts.push('staticjs');
+
+// The old version of metro doesn't support `.cjs` files as `main` entry points,
+// so we need to register the extension here to avoid resolution failures.
+// https://github.com/facebook/metro/issues/535
+defaultConfig.resolver.sourceExts.push('cjs');
 
 defaultConfig.server.rewriteRequestUrl = (url) => {
 	if (!url.endsWith('.bundle')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2135,9 +2135,9 @@
       "dev": true
     },
     "@jellyfin/sdk": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@jellyfin/sdk/-/sdk-0.11.0.tgz",
-      "integrity": "sha512-WmM4as9ptqH+CvC2YsUefNWQDmu2aWIamwAoj7h2BFR6l019pcRFG5FT22egwbdizR6DfdpmsoAWB4x9QCzcEQ==",
+      "version": "0.0.0-unstable.202607220710",
+      "resolved": "https://registry.npmjs.org/@jellyfin/sdk/-/sdk-0.0.0-unstable.202607220710.tgz",
+      "integrity": "sha512-5gwbKhre7R2/aZYww2TVFM7Pug5t8MWWLSTKLZnS67dfhF5SST1FC06R7lO6jwZYEB4YFCQNKxAT+TS9dsMHcA==",
       "requires": {}
     },
     "@jellyfin/ux-ios": {
@@ -4405,7 +4405,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -4724,13 +4723,14 @@
       }
     },
     "axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "requires": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "babel-core": {
@@ -7692,9 +7692,9 @@
       "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg=="
     },
     "follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "fontfaceobserver": {
       "version": "2.3.0",
@@ -7716,14 +7716,15 @@
       "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ=="
     },
     "form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       }
     },
     "fragment-cache": {
@@ -8109,9 +8110,9 @@
       }
     },
     "hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "requires": {
         "function-bind": "^1.1.2"
       },
@@ -8222,7 +8223,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -12458,9 +12458,9 @@
       }
     },
     "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
     },
     "psl": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "Android >= 5"
   ],
   "dependencies": {
-    "@jellyfin/sdk": "0.11.0",
+    "@jellyfin/sdk": "0.0.0-unstable.202607220710",
     "@jellyfin/ux-ios": "1.0.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-native-community/masked-view": "0.1.11",
@@ -48,7 +48,7 @@
     "@react-navigation/native": "6.1.18",
     "@react-navigation/native-stack": "6.11.0",
     "@react-navigation/stack": "6.4.1",
-    "axios": "1.9.0",
+    "axios": "1.18.1",
     "compare-versions": "3.6.0",
     "expo": "~46.0.21",
     "expo-application": "~4.2.2",


### PR DESCRIPTION
### Changes
- Updates axios to the latest version and the SDK to the latest unstable version
- Fixes references to removed APIs
- Fixes support for `cjs` entry points

### Issues
N/A

### Code assistance
Used Claude Sonnet 5 to debug the cjs entry point issue

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-ios/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another iOS PR](https://github.com/jellyfin/jellyfin-ios/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
