### PR TITLE
Fix download support for Jellyfin v12

### DIFF
--- a/components/NativeShellWebView.tsx
+++ b/components/NativeShellWebView.tsx
@@ -6,8 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { AUTHORIZATION_PARAMETER } from '@jellyfin/sdk/lib/constants';
 import { MediaType } from '@jellyfin/sdk/lib/generated-client/models/media-type';
-import compareVersions from 'compare-versions';
 import { nativeApplicationVersion } from 'expo-application';
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React, { ForwardRefRenderFunction, useImperativeHandle, useRef, useState } from 'react';
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { Alert, BackHandler, Platform } from 'react-native';
 import type { WebView, WebViewMessageEvent } from 'react-native-webview';
 
+import { LEGACY_AUTHORIZATION_PARAMETER } from '../constants/api';
 import { useStores } from '../hooks/useStores';
 import DownloadModel from '../models/DownloadModel';
 import { getAppName, getDeviceProfile, getSafeDeviceName } from '../utils/Device';
@@ -100,16 +101,18 @@ true;
 				case 'downloadFile': {
 					console.log('Download item', data);
 
+					const title = data?.item?.item?.Name || data?.item?.filename;
+
 					// Get the API key from the download URL
 					let apiKey;
 					try {
 						const url = new URL(data.item.url);
-						apiKey = url.searchParams.get('api_key');
+						apiKey = url.searchParams.get(AUTHORIZATION_PARAMETER) || url.searchParams.get(LEGACY_AUTHORIZATION_PARAMETER);
 					} catch (e) {
 						console.error('[NativeShellWebView] downloadFile: failed to get api key from download url', data.item?.url);
 						Alert.alert(
 							t('alerts.downloadFailed.title'),
-							t('alerts.downloadFailed.description')
+							t('alerts.downloadFailed.description', { title })
 						);
 						break;
 					}
@@ -123,7 +126,7 @@ true;
 						});
 						Alert.alert(
 							t('alerts.downloadFailed.title'),
-							t('alerts.downloadFailed.description')
+							t('alerts.downloadFailed.description', { title })
 						);
 						break;
 					}

--- a/constants/api.ts
+++ b/constants/api.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Jellyfin Contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Legacy authorization parameter name used in Jellyfin download URLs in versions <= 10.11.
+ * @deprecated
+ */
+export const LEGACY_AUTHORIZATION_PARAMETER = 'api_key';


### PR DESCRIPTION
### Changes
- Fixes download support only checking for the legacy authorization parameter
- Removes an unused import
- Fixes error alerts showing placeholder text

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-ios/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another iOS PR](https://github.com/jellyfin/jellyfin-ios/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
