### PR TITLE
Fix server version display for 12.0

### DIFF
--- a/components/ServerListItem.js
+++ b/components/ServerListItem.js
@@ -1,4 +1,6 @@
 /**
+ * Copyright (c) 2026 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -16,7 +18,7 @@ const ServerListItem = ({ item, index, activeServer, onDelete, onPress }) => {
 	const { theme } = useContext(ThemeContext);
 
 	const title = item?.name;
-	const version = item?.info?.Version || t('common.unknown');
+	const version = item?.version || t('common.unknown');
 	const subtitle = `${t('settings.version', { version })}\n${item.urlString}`;
 
 	return (

--- a/components/__tests__/ServerListItem.test.js
+++ b/components/__tests__/ServerListItem.test.js
@@ -1,4 +1,6 @@
 /**
+* Copyright (c) 2026 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -18,10 +20,8 @@ describe('ServerListItem', () => {
 			<ServerListItem
 				item={{
 					name: 'Test Server',
-					info: {
-						Version: '10.0.0'
-					},
-					urlString: 'https://foobar'
+					urlString: 'https://foobar',
+					version: '10.0.0'
 				}}
 				index={0}
 				activeServer={0}

--- a/components/__tests__/ServerListItem.test.js
+++ b/components/__tests__/ServerListItem.test.js
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2026 Jellyfin Contributors
+ * Copyright (c) 2026 Jellyfin Contributors
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/models/ServerModel.js
+++ b/models/ServerModel.js
@@ -1,8 +1,12 @@
 /**
+ * Copyright (c) 2026 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import { getDisplayVersion } from '@jellyfin/sdk/lib/utils/versioning';
+
 import { fetchServerInfo, getServerUrl } from '../utils/ServerValidator';
 
 export default class ServerModel {
@@ -31,6 +35,10 @@ export default class ServerModel {
 		} catch (ex) {
 			return '';
 		}
+	}
+
+	get version() {
+		return getDisplayVersion(this.info?.Version);
 	}
 
 	fetchInfo = () => fetchServerInfo(this)

--- a/models/ServerModel.ts
+++ b/models/ServerModel.ts
@@ -5,20 +5,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import { PublicSystemInfo } from '@jellyfin/sdk/lib/generated-client/models/public-system-info';
 import { getDisplayVersion } from '@jellyfin/sdk/lib/utils/versioning';
 
 import { fetchServerInfo, getServerUrl } from '../utils/ServerValidator';
 
 export default class ServerModel {
-	id
-
-	url
-
+	id: string
+	url: URL
+	urlString: string
 	online = false
+	info?: PublicSystemInfo
 
-	info
-
-	constructor(id, url, info) {
+	constructor(id: string, url: URL, info?: PublicSystemInfo) {
 		this.id = id;
 		this.url = url;
 		this.info = info;

--- a/models/__tests__/ServerModel.test.js
+++ b/models/__tests__/ServerModel.test.js
@@ -1,4 +1,6 @@
 /**
+ * Copyright (c) 2026 Jellyfin Contributors
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -19,7 +21,8 @@ describe('ServerModel', () => {
 			'testId',
 			new URL('https://foobar'),
 			{
-				ServerName: 'Test Server'
+				ServerName: 'Test Server',
+				Version: '12.0.0'
 			}
 		);
 
@@ -27,6 +30,7 @@ describe('ServerModel', () => {
 		expect(server.online).toBe(false);
 		expect(server.urlString).toBe('https://foobar/');
 		expect(server.name).toBe('Test Server');
+		expect(server.version).toBe('12.0');
 	});
 
 	it('should fallback to the url if server name is unavailable', () => {


### PR DESCRIPTION
### Changes
- Updates the server version display to use the SDK util to properly display "12.0"
- Converts `ServerModel` to TypeScript

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-ios/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another iOS PR](https://github.com/jellyfin/jellyfin-ios/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
