### PR TITLE
Replace compare-versions dependency with sdk util

### DIFF
--- a/components/MenuViewButton/index.ios.tsx
+++ b/components/MenuViewButton/index.ios.tsx
@@ -6,8 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { compareVersions } from '@jellyfin/sdk/lib/utils/versioning';
 import { MenuView } from '@react-native-menu/menu';
-import compareVersions from 'compare-versions';
 import React, { useCallback, useContext, type FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActionSheetIOS, Platform } from 'react-native';
@@ -16,7 +16,7 @@ import { ListItem, ThemeContext } from 'react-native-elements';
 import type { MenuViewButtonProps } from './types';
 
 const isMenuSupported = !Platform.Version // Version is undefined in tests
-	|| compareVersions.compare(String(Platform.Version), '13', '>=');
+	|| compareVersions(String(Platform.Version), '13') >= 0;
 
 /**
  * A Button component that opens a MenuView with fallback to Action Sheet for iOS 12.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2057,7 +2057,8 @@
     "@graphql-typed-document-node/core": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.2.tgz",
-      "integrity": "sha512-9anpBMM9mEgZN4wr2v8wHJI2/u5TnnggewRN6OlvXTTnuVyoY19X6rOv9XTqKRw6dcGKwZsBi8n0kDE2I5i4VA=="
+      "integrity": "sha512-9anpBMM9mEgZN4wr2v8wHJI2/u5TnnggewRN6OlvXTTnuVyoY19X6rOv9XTqKRw6dcGKwZsBi8n0kDE2I5i4VA==",
+      "requires": {}
     },
     "@hapi/hoek": {
       "version": "9.3.0",
@@ -2150,7 +2151,8 @@
     "@jellyfin/sdk": {
       "version": "0.0.0-unstable.202607220710",
       "resolved": "https://registry.npmjs.org/@jellyfin/sdk/-/sdk-0.0.0-unstable.202607220710.tgz",
-      "integrity": "sha512-5gwbKhre7R2/aZYww2TVFM7Pug5t8MWWLSTKLZnS67dfhF5SST1FC06R7lO6jwZYEB4YFCQNKxAT+TS9dsMHcA=="
+      "integrity": "sha512-5gwbKhre7R2/aZYww2TVFM7Pug5t8MWWLSTKLZnS67dfhF5SST1FC06R7lO6jwZYEB4YFCQNKxAT+TS9dsMHcA==",
+      "requires": {}
     },
     "@jellyfin/ux-ios": {
       "version": "1.0.0",
@@ -3215,7 +3217,8 @@
         "ws": {
           "version": "7.5.9",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "requires": {}
         }
       }
     },
@@ -3325,12 +3328,14 @@
     "@react-native-community/masked-view": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@react-native-community/masked-view/-/masked-view-0.1.11.tgz",
-      "integrity": "sha512-rQfMIGSR/1r/SyN87+VD8xHHzDYeHaJq6elOSCAD+0iLagXkSI2pfA0LmSXP21uw5i3em7GkkRjfJ8wpqWXZNw=="
+      "integrity": "sha512-rQfMIGSR/1r/SyN87+VD8xHHzDYeHaJq6elOSCAD+0iLagXkSI2pfA0LmSXP21uw5i3em7GkkRjfJ8wpqWXZNw==",
+      "requires": {}
     },
     "@react-native-menu/menu": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@react-native-menu/menu/-/menu-1.2.4.tgz",
-      "integrity": "sha512-63NU9NHd/KcBa7lhhV69xQmY3ORUxjMRmlzTY/qrY56GHnuKX+16dvUpKAuRSPK5kebBuRw5X4MFe2L9JHUlWA=="
+      "integrity": "sha512-63NU9NHd/KcBa7lhhV69xQmY3ORUxjMRmlzTY/qrY56GHnuKX+16dvUpKAuRSPK5kebBuRw5X4MFe2L9JHUlWA==",
+      "requires": {}
     },
     "@react-native/assets": {
       "version": "1.0.0",
@@ -3373,7 +3378,8 @@
     "@react-navigation/elements": {
       "version": "1.3.31",
       "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.31.tgz",
-      "integrity": "sha512-bUzP4Awlljx5RKEExw8WYtif8EuQni2glDaieYROKTnaxsu9kEIA515sXQgUDZU4Ob12VoL7+z70uO3qrlfXcQ=="
+      "integrity": "sha512-bUzP4Awlljx5RKEExw8WYtif8EuQni2glDaieYROKTnaxsu9kEIA515sXQgUDZU4Ob12VoL7+z70uO3qrlfXcQ==",
+      "requires": {}
     },
     "@react-navigation/native": {
       "version": "6.1.18",
@@ -4400,7 +4406,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -4743,7 +4750,8 @@
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "requires": {}
     },
     "babel-jest": {
       "version": "26.6.3",
@@ -6828,7 +6836,8 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
       "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.37.4",
@@ -7194,7 +7203,8 @@
     "expo-application": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-4.2.2.tgz",
-      "integrity": "sha512-bFEaFRUdV6aK2iBd+HzkHNPYsyj88EAhaQW5leznmO0qQMJxpAQ3eoUXMey1hfDBh1qgkkHgSyCZ9BIgMAGJ1g=="
+      "integrity": "sha512-bFEaFRUdV6aK2iBd+HzkHNPYsyj88EAhaQW5leznmO0qQMJxpAQ3eoUXMey1hfDBh1qgkkHgSyCZ9BIgMAGJ1g==",
+      "requires": {}
     },
     "expo-asset": {
       "version": "8.6.3",
@@ -7246,7 +7256,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/expo-error-recovery/-/expo-error-recovery-3.2.0.tgz",
       "integrity": "sha512-XZ630ks5HNxa9oc2Ya1hEn1ez031Cy4VnyxerPC2o9fKNKSrD/64cRqGF9NkGM3X2uf8+PCB9adxVflAIXBf6w==",
-      "optional": true
+      "optional": true,
+      "requires": {}
     },
     "expo-file-system": {
       "version": "14.1.0",
@@ -7275,7 +7286,8 @@
     "expo-keep-awake": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-10.2.1.tgz",
-      "integrity": "sha512-UBge1BwzDPhUFX0gKu9eDLwEFj4LGiqrOogNoEYxcosM1SwhkbWwPrd3zZtl53LLz02TxEi/CI/MUGJJsrVQLw=="
+      "integrity": "sha512-UBge1BwzDPhUFX0gKu9eDLwEFj4LGiqrOogNoEYxcosM1SwhkbWwPrd3zZtl53LLz02TxEi/CI/MUGJJsrVQLw==",
+      "requires": {}
     },
     "expo-linking": {
       "version": "3.2.4",
@@ -7362,7 +7374,8 @@
     "expo-sharing": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-10.3.0.tgz",
-      "integrity": "sha512-j3kn43WCOykj7mlGTb5Q3Z56DG8raFdTk0A+rauA7lsmJ5Vakb2qGyTFZ7uwqwrML10EQIPAzNEcEYgpIzHKIw=="
+      "integrity": "sha512-j3kn43WCOykj7mlGTb5Q3Z56DG8raFdTk0A+rauA7lsmJ5Vakb2qGyTFZ7uwqwrML10EQIPAzNEcEYgpIzHKIw==",
+      "requires": {}
     },
     "expo-splash-screen": {
       "version": "0.16.2",
@@ -9557,7 +9570,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -10642,7 +10656,8 @@
           "version": "7.5.10",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
           "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -11150,7 +11165,8 @@
         "ws": {
           "version": "7.5.9",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "requires": {}
         }
       }
     },
@@ -11244,7 +11260,8 @@
         "ws": {
           "version": "7.5.9",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "requires": {}
         }
       }
     },
@@ -12567,7 +12584,8 @@
         "ws": {
           "version": "7.5.9",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "requires": {}
         }
       }
     },
@@ -12583,7 +12601,8 @@
     "react-freeze": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.3.tgz",
-      "integrity": "sha512-ZnXwLQnGzrDpHBHiC56TXFXvmolPeMjTn1UOm610M4EXGzbEDR7oOIyS2ZiItgbs6eZc4oU/a0hpk8PrcKvv5g=="
+      "integrity": "sha512-ZnXwLQnGzrDpHBHiC56TXFXvmolPeMjTn1UOm610M4EXGzbEDR7oOIyS2ZiItgbs6eZc4oU/a0hpk8PrcKvv5g==",
+      "requires": {}
     },
     "react-i18next": {
       "version": "11.18.6",
@@ -12830,7 +12849,8 @@
     "react-native-safe-area-context": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.3.1.tgz",
-      "integrity": "sha512-cEr7fknJCToTrSyDCVNg0GRdRMhyLeQa2NZwVCuzEQcWedOw/59ExomjmzCE4rxrKXs6OJbyfNtFRNyewDaHuA=="
+      "integrity": "sha512-cEr7fknJCToTrSyDCVNg0GRdRMhyLeQa2NZwVCuzEQcWedOw/59ExomjmzCE4rxrKXs6OJbyfNtFRNyewDaHuA==",
+      "requires": {}
     },
     "react-native-screens": {
       "version": "3.15.0",
@@ -12844,7 +12864,8 @@
     "react-native-size-matters": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.3.1.tgz",
-      "integrity": "sha512-mKOfBLIBFBcs9br1rlZDvxD5+mAl8Gfr5CounwJtxI6Z82rGrMO+Kgl9EIg3RMVf3G855a85YVqHJL2f5EDRlw=="
+      "integrity": "sha512-mKOfBLIBFBcs9br1rlZDvxD5+mAl8Gfr5CounwJtxI6Z82rGrMO+Kgl9EIg3RMVf3G855a85YVqHJL2f5EDRlw==",
+      "requires": {}
     },
     "react-native-url-polyfill": {
       "version": "1.3.0",
@@ -14184,6 +14205,14 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string-hash-64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
@@ -14297,14 +14326,6 @@
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -14693,7 +14714,8 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "picomatch": {
           "version": "4.0.3",
@@ -15203,12 +15225,14 @@
     "use-latest-callback": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.1.tgz",
-      "integrity": "sha512-QWlq8Is8BGWBf883QOEQP5HWYX/kMI+JTbJ5rdtvJLmXTIh9XoHIO3PQcmQl8BU44VKxow1kbQUHa6mQSMALDQ=="
+      "integrity": "sha512-QWlq8Is8BGWBf883QOEQP5HWYX/kMI+JTbJ5rdtvJLmXTIh9XoHIO3PQcmQl8BU44VKxow1kbQUHa6mQSMALDQ==",
+      "requires": {}
     },
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -15655,7 +15679,8 @@
     "zustand": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
-      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg=="
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@react-navigation/native-stack": "6.11.0",
     "@react-navigation/stack": "6.4.1",
     "axios": "1.18.1",
-    "compare-versions": "3.6.0",
     "expo": "~46.0.21",
     "expo-application": "~4.2.2",
     "expo-asset": "~8.6.3",

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -6,9 +6,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { compareVersions } from '@jellyfin/sdk/lib/utils/versioning';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
-import compareVersions from 'compare-versions';
 import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Alert, Platform, SectionList, StyleSheet, View } from 'react-native';
@@ -142,7 +142,7 @@ const SettingsScreen = () => {
 				}
 			});
 
-			if (compareVersions.compare(Platform.Version, '12', '>')) {
+			if (compareVersions(String(Platform.Version), '12') > 0) {
 				playbackSettingsData.push({
 					key: 'native-video-fmp4-switch',
 					title: t('settings.fmp4Support'),

--- a/stores/SettingStore.ts
+++ b/stores/SettingStore.ts
@@ -6,8 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { compareVersions } from '@jellyfin/sdk/lib/utils/versioning';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import compareVersions from 'compare-versions';
 import { Platform } from 'react-native';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
@@ -66,7 +66,7 @@ const initialState: () => State = () => ({
 	activeServer: 0,
 	isRotationLockEnabled: Platform.OS === 'ios' && !Platform.isPad,
 	isScreenLockEnabled: Platform.OS === 'ios'
-		? !!Platform.Version && compareVersions.compare(Platform.Version, '14', '<')
+		? !!Platform.Version && compareVersions(String(Platform.Version), '14') < 0
 		: true,
 	isTabLabelsEnabled: true,
 	themeId: 'dark',

--- a/utils/Device.ts
+++ b/utils/Device.ts
@@ -7,7 +7,7 @@
  */
 
 import type { DeviceProfile } from '@jellyfin/sdk/lib/generated-client/models/device-profile';
-import compareVersions from 'compare-versions';
+import { compareVersions } from '@jellyfin/sdk/lib/utils/versioning';
 import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import { Platform } from 'react-native';
@@ -47,9 +47,9 @@ export function getSafeDeviceName() {
 
 export function getDeviceProfile({ enableFmp4 = false } = {}): DeviceProfile {
 	if (Platform.OS === 'ios') {
-		if (compareVersions.compare(Platform.Version, '11', '<')) {
+		if (compareVersions(String(Platform.Version), '11') < 0) {
 			return iOS10Profile;
-		} else if (compareVersions.compare(Platform.Version, '13', '<')) {
+		} else if (compareVersions(String(Platform.Version), '13') < 0) {
 			return iOS11Profile;
 		} else if (enableFmp4) {
 			return iOS13Fmp4Profile;
@@ -67,6 +67,6 @@ export function isCompact({ height = 500 } = {}) {
 
 // Does the platform support system level themes: https://docs.expo.io/versions/latest/sdk/appearance/
 export function isSystemThemeSupported() {
-	return (Platform.OS === 'ios' && compareVersions.compare(Platform.Version, '12', '>')) ||
-		(Platform.OS === 'android' && compareVersions.compare(String(Platform.Version), '9', '>'));
+	return (Platform.OS === 'ios' && compareVersions(String(Platform.Version), '12') > 0) ||
+		(Platform.OS === 'android' && compareVersions(String(Platform.Version), '9') > 0);
 }


### PR DESCRIPTION
### Changes
Replaces the dependency on compare-versions with the sdk utility

### Issues
N/A

### Code assistance
Zed autocomplete

---

* [x] I have read and followed the [contributing guidelines](https://github.com/jellyfin/jellyfin-ios/blob/master/CONTRIBUTING.md).
* [x] I have tested these changes.
* [x] I have verified that this is not duplicating changes in an existing PR.
* [x] I have provided a *substantive* review of [another iOS PR](https://github.com/jellyfin/jellyfin-ios/pulls?q=is%3Apr+is%3Aopen+-label%3Adependencies+-label%3Ablocked+-label%3Abackend+-label%3Ainvalid+-label%3A"merge+conflict"+-label%3Astale+-author%3A%40me).
